### PR TITLE
don't expect attributes from recipes steps

### DIFF
--- a/tests/testthat/test-step_expose.R
+++ b/tests/testthat/test-step_expose.R
@@ -9,6 +9,8 @@ expo_dat <- expose_py(toy_census, "2022-12-31",
   select(all_of(names(rec_dat)))
 
 test_that("step_expose is identical to expose", {
+  attributes(rec_dat) <- NULL
+  attributes(expo_dat) <- NULL
   expect_identical(rec_dat, expo_dat)
 })
 


### PR DESCRIPTION
Hello @mattheaphy 👋 

I was doing a reverse dependency check on {recipes} as we are gearing up for a release. We found a test that failed in your package.

A recent change we made was to stop recipe steps from being able to return tibbles with attributes as we were having a great deal of issues with that, and wasn't able to code around it.

This PR updates one of your tests to reflect this change in behavior in {recipes}. This PR can be merged in now as it is backwards compatible with CRAN version of {recipes}.

We are planing a CRAN release on the 24th of April so it be great if you are able to update and release before then.

Thank you so much, and sorry about changed behavior.