### PR TITLE
dplyr and gt compatibility updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,14 +34,14 @@ Depends:
     R (>= 4.1)
 Imports: 
     lubridate,
-    dplyr (>= 1.1.0),
+    dplyr (>= 1.1.1),
     ggplot2,
     tibble,
     rlang,
     glue,
     purrr,
     scales,
-    gt,
+    gt (>= 0.9.0),
     paletteer,
     recipes,
     generics,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # actxps 1.1.0
 
 - New `add_predictions()` function that attaches one or more columns of model predictions to an `exposed_df` object or any other data frame.
+- Small updates to `add_transactions()` and `autotable()` functions for compatibility with the dplyr 1.1.1 and gt 0.9.0.
 
 # actxps 1.0.1
 

--- a/R/exp_stats.R
+++ b/R/exp_stats.R
@@ -95,7 +95,7 @@ exp_stats <- function(.data, target_status = attr(.data, "target_status"),
 
   res <- .data |>
     rename(exposure = {{col_exposure}},
-                  status = {{col_status}}) |>
+           status = {{col_status}}) |>
     mutate(n_claims = status %in% target_status)
 
   if (!is.null(wt)) {
@@ -120,9 +120,11 @@ exp_stats <- function(.data, target_status = attr(.data, "target_status"),
 #' @export
 print.exp_df <- function(x, ...) {
 
-  cat("Experience study results\n\n",
-      "Groups:", paste(groups(x), collapse = ", "), "\n",
-      "Target status:", paste(attr(x, "target_status"), collapse = ", "), "\n",
+  cat("Experience study results\n\n")
+  if (length(groups(x)) > 0) {
+    cat("Groups:", paste(groups(x), collapse = ", "), "\n")
+  }
+  cat(" Target status:", paste(attr(x, "target_status"), collapse = ", "), "\n",
       "Study range:", as.character(attr(x, "start_date")), "to",
       as.character(attr(x, "end_date")), "\n")
   if (!is.null(attr(x, "expected"))) {
@@ -242,7 +244,7 @@ finish_exp_stats <- function(.data, target_status, expected,
     res <- res |>
       select(-ex_wt, -ex2_wt) |>
       relocate(.weight, .weight_sq, .weight_n,
-                      .after = dplyr::last_col())
+               .after = dplyr::last_col())
   }
 
   tibble::new_tibble(res,

--- a/R/exposed_df_helpers.R
+++ b/R/exposed_df_helpers.R
@@ -30,8 +30,8 @@
 #' @param cols_dates Optional. Names of the columns in `x` containing exposure
 #' start and end dates. Both date ranges are assumed to be exclusive. The
 #' assumed default is of the form *A*_*B*. *A* is "cal" if `cal_expo` is `TRUE`
-#' or "pol" otherwise. *B* is either "pol_yr", "pol_qtr", "pol_mth", or "pol_wk"
-#' depending on the value of `expo_length`.
+#' or "pol" otherwise. *B* is either "yr", "qtr", "mth", or "wk" depending on
+#' the value of `expo_length`.
 #' @param col_trx_n_ Optional. Prefix to use for columns containing transaction
 #' counts.
 #' @param col_trx_amt_ Optional. Prefix to use for columns containing transaction

--- a/R/exposed_df_helpers.R
+++ b/R/exposed_df_helpers.R
@@ -35,7 +35,7 @@
 #' @param col_trx_n_ Optional. Prefix to use for columns containing transaction
 #' counts.
 #' @param col_trx_amt_ Optional. Prefix to use for columns containing transaction
-#' amount.
+#' amounts.
 #' @inheritParams expose
 #'
 #' @return For `is_exposed_df()`, a length-1 logical vector. For

--- a/R/exposed_df_helpers.R
+++ b/R/exposed_df_helpers.R
@@ -100,7 +100,7 @@ as_exposed_df <- function(x, end_date, start_date = as.Date("1900-01-01"),
   }
 
   # check transaction types
-  exp_cols_trx <- if(!is.null(trx_types)) {
+  if(!is.null(trx_types)) {
 
     trx_renamer <- function(x) {
       x <- gsub(paste0("^", col_trx_n_), "trx_n_", x)
@@ -112,6 +112,8 @@ as_exposed_df <- function(x, end_date, start_date = as.Date("1900-01-01"),
     trx_types <- unique(trx_types)
     exp_cols_trx <- outer(c("trx_n_", "trx_amt_"), trx_types, paste0) |>
       as.character()
+  } else {
+    exp_cols_trx <- NULL
   }
 
   # check required columns

--- a/R/tables.R
+++ b/R/tables.R
@@ -114,7 +114,7 @@ autotable.exp_df <- function(object, fontsize = 100, decimals = 1,
     tab <- tab |>
       gt::data_color(
         columns = q_obs,
-        colors = scales::col_numeric(
+        fn = scales::col_numeric(
           palette = paletteer::paletteer_d(palette = color_q_obs) |>
             as.character(),
           domain = NULL
@@ -122,7 +122,7 @@ autotable.exp_df <- function(object, fontsize = 100, decimals = 1,
       ) |>
       gt::data_color(
         columns = dplyr::starts_with("ae_"),
-        colors = scales::col_numeric(
+        fn = scales::col_numeric(
           palette = paletteer::paletteer_d(palette = color_ae_) |>
             as.character(),
           domain = domain_ae,
@@ -153,7 +153,7 @@ autotable.trx_df <- function(object, fontsize = 100, decimals = 1,
   if (!is.null(percent_of)) {
     object <- object |>
       select(-dplyr::all_of(percent_of),
-                    -dplyr::all_of(paste0(percent_of, "_w_trx")))
+             -dplyr::all_of(paste0(percent_of, "_w_trx")))
   }
 
   tab <- object |>
@@ -200,7 +200,7 @@ autotable.trx_df <- function(object, fontsize = 100, decimals = 1,
     tab <- tab |>
       gt::data_color(
         columns = trx_util,
-        colors = scales::col_numeric(
+        fn = scales::col_numeric(
           palette = paletteer::paletteer_d(palette = color_util) |>
             as.character(),
           domain = NULL
@@ -208,7 +208,7 @@ autotable.trx_df <- function(object, fontsize = 100, decimals = 1,
       ) |>
       gt::data_color(
         columns = dplyr::starts_with("pct_of"),
-        colors = scales::col_numeric(
+        fn = scales::col_numeric(
           palette = paletteer::paletteer_d(palette = color_pct_of) |>
             as.character(),
           domain = domain_pct,

--- a/R/transactions.R
+++ b/R/transactions.R
@@ -80,7 +80,7 @@ add_transactions <- function(.data, trx_data,
   trx_data <- trx_data |>
     # between-join by transaction date falling within exposures windows
     inner_join(
-      date_lookup, multiple = "error",
+      date_lookup, relationship = "many-to-one",
       dplyr::join_by(pol_num,
                      between(trx_date, !!date_cols[[1]], !!date_cols[[2]])))
 

--- a/R/transactions.R
+++ b/R/transactions.R
@@ -62,9 +62,9 @@ add_transactions <- function(.data, trx_data,
   # # column renames
   trx_data <- trx_data |>
     rename(pol_num = {{col_pol_num}},
-                  trx_date = {{col_trx_date}},
-                  trx_type = {{col_trx_type}},
-                  trx_amt = {{col_trx_amt}})
+           trx_date = {{col_trx_date}},
+           trx_type = {{col_trx_type}},
+           trx_amt = {{col_trx_amt}})
 
 
   # check for conflicting transaction types
@@ -100,6 +100,6 @@ add_transactions <- function(.data, trx_data,
   .data |>
     left_join(trx_data, dplyr::join_by(pol_num, !!date_cols[[1]])) |>
     mutate(dplyr::across(dplyr::starts_with("trx_"), \(x)
-                                dplyr::coalesce(x, 0)))
+                         dplyr::coalesce(x, 0)))
 
 }

--- a/R/trx_stats.R
+++ b/R/trx_stats.R
@@ -160,7 +160,7 @@ trx_stats <- function(.data,
 
   .data <- .data |>
     select(pol_num, exposure, !!!.groups,
-                  dplyr::all_of(trx_cols), dplyr::all_of(percent_of)) |>
+           dplyr::all_of(trx_cols), dplyr::all_of(percent_of)) |>
     tidyr::pivot_longer(dplyr::all_of(trx_cols),
                         names_to = c(".value", "trx_type"),
                         names_pattern = "^(trx_(?:amt|n))_(.*)$") |>
@@ -174,9 +174,11 @@ trx_stats <- function(.data,
 #' @export
 print.trx_df <- function(x, ...) {
 
-  cat("Transaction study results\n\n",
-      "Groups:", paste(groups(x), collapse = ", "), "\n",
-      "Study range:", as.character(attr(x, "start_date")), "to",
+  cat("Transaction study results\n\n")
+  if (length(groups(x)) > 0) {
+    cat("Groups:", paste(groups(x), collapse = ", "), "\n")
+  }
+  cat(" Study range:", as.character(attr(x, "start_date")), "to",
       as.character(attr(x, "end_date")), "\n",
       "Transaction types:", paste(attr(x, "trx_types"), collapse = ", "), "\n")
   if (!is.null(attr(x, "percent_of"))) {

--- a/R/trx_stats.R
+++ b/R/trx_stats.R
@@ -184,11 +184,6 @@ print.trx_df <- function(x, ...) {
   if (!is.null(attr(x, "percent_of"))) {
     cat(" Transactions as % of:", paste(attr(x, "percent_of"), collapse = ", "), "\n")
   }
-  if (is.null(attr(x, "wt"))) {
-    cat("\n")
-  } else {
-    cat(" Weighted by:", attr(x, "wt"), "\n\n")
-  }
 
   NextMethod()
 }

--- a/man/is_exposed_df.Rd
+++ b/man/is_exposed_df.Rd
@@ -68,7 +68,7 @@ the value of \code{expo_length}.}
 counts.}
 
 \item{col_trx_amt_}{Optional. Prefix to use for columns containing transaction
-amount.}
+amounts.}
 }
 \value{
 For \code{is_exposed_df()}, a length-1 logical vector. For

--- a/man/is_exposed_df.Rd
+++ b/man/is_exposed_df.Rd
@@ -61,8 +61,8 @@ the value of \code{expo_length}.}
 \item{cols_dates}{Optional. Names of the columns in \code{x} containing exposure
 start and end dates. Both date ranges are assumed to be exclusive. The
 assumed default is of the form \emph{A}_\emph{B}. \emph{A} is "cal" if \code{cal_expo} is \code{TRUE}
-or "pol" otherwise. \emph{B} is either "pol_yr", "pol_qtr", "pol_mth", or "pol_wk"
-depending on the value of \code{expo_length}.}
+or "pol" otherwise. \emph{B} is either "yr", "qtr", "mth", or "wk" depending on
+the value of \code{expo_length}.}
 
 \item{col_trx_n_}{Optional. Prefix to use for columns containing transaction
 counts.}

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -25,12 +25,6 @@ expo <- expo |> group_by(product, .add = TRUE)
 exp_res4 <- exp_stats2(expo)
 trx_res4 <- trx_stats2(expo)
 
-
-toy_res <- toy_census |>
-  expose_py(end_date = "2022-12-31", target_status = "Surrender") |>
-  dplyr::group_by(pol_yr) |>
-  exp_stats()
-
 test_that("Autoplot works", {
   expect_s3_class(autoplot(exp_res), c("gg", "ggplot"))
   expect_s3_class(autoplot(exp_res2), c("gg", "ggplot"))


### PR DESCRIPTION
- Small updates to `add_transactions()` and `autotable()` functions for compatibility with the dplyr 1.1.1 and gt 0.9.0.
- Minor improvements to print methods for `exp_stats()` and `trx_stats()`

