### PR TITLE
Confidence interval update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: actxps
 Title: Create Actuarial Experience Studies: Prepare Data, Summarize Results, and Create Reports
-Version: 1.2.0
+Version: 1.2.0.9000
 Authors@R: 
     person("Matt", "Heaphy", email = "mattrmattrs@gmail.com", role = c("aut", "cre"))
 Maintainer: Matt Heaphy <mattrmattrs@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,27 @@
 # actxps (development version)
 
+- A new `conf_int` argument was added to `exp_stats()` and that creates confidence 
+intervals around observed termination rates, credibility-weighted termination 
+rates, and any actual-to-expected ratios.
+- Similarly, `conf_int` was added to `trx_stats()` to create confidence intervals around utilization rates and any "percentage of" output columns. A `conf_level`
+argument was also added to this function.
+- `autoplot.exp_df()` and `autoplot.trx_df()` now have a `conf_int_bars` argument 
+that plots confidence intervals (if available) as error bars for the selected 
+y-variable
+- `autoplot.exp_df()` and `autoplot.trx_df()` can now create scatter plots if
+"points" is passed to the `geoms` argument.
+- The second y-axis in the `autoplot()` methods was updated to use an area 
+geometry instead of bars for discrete x-axis variables. In addition, when a 
+log-10 y-scale is used, areas will always be positive quantities. Previously,
+it was observed that areas were drawn as negative values for y-values on the 
+main scale less than 1.
+- `autotable.exp_df()` and `autotable.trx_df()` were updated to format 
+intervals.
+- **Breaking change** - The confidence level argument `cred_p` was renamed to 
+`conf_level`. This change was made because the confidence level is no longer 
+strictly used for credibility calculations. This change impacts the functions
+`exp_stats()` and `exp_shiny()`.
+
 # actxps 1.2.0
 
 - `autoplot.exp_df()` and `autoplot.trx_df()` now include new options for adding a second y-axis and plotting results on a log-10 scale. The second y-axis defaults to plotting exposures using an area geometry.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
+# actxps (development version)
+
 # actxps 1.2.0
 
-- `autoplot.exp_df` and `autoplot.trx_df()` now include new options for adding a second y-axis and plotting results on a log-10 scale. The second y-axis defaults to plotting exposures using an area geometry.
+- `autoplot.exp_df()` and `autoplot.trx_df()` now include new options for adding a second y-axis and plotting results on a log-10 scale. The second y-axis defaults to plotting exposures using an area geometry.
 - New plotting functions were added to create common experience analysis plots that were not simple to create using `autoplot()` methods. These include `plot_termination_rates()` and `plot_actual_to_expected()` for termination studies and `plot_utilization_rates()` for transaction studies
 - The `exp_shiny()` function received a handful of updates to accommodate new plotting functions and options. A small performance improvement was added in filtering logic as well. New options include a title input, credibility options taken from `exp_stats()`, 
 - A new vignette was added on data visualization.

--- a/R/exp_shiny.R
+++ b/R/exp_shiny.R
@@ -106,7 +106,8 @@
 #'
 #' if (interactive()) {
 #'   study_py <- expose_py(census_dat, "2019-12-31", target_status = "Surrender")
-#'   expected_table <- c(seq(0.005, 0.03, length.out = 10), 0.2, 0.15, rep(0.05, 3))
+#'   expected_table <- c(seq(0.005, 0.03, length.out = 10),
+#'                       0.2, 0.15, rep(0.05, 3))
 #'
 #'   study_py <- study_py |>
 #'     mutate(expected_1 = expected_table[pol_yr],
@@ -401,6 +402,9 @@ exp_shiny <- function(dat,
                 width = 4,
                 shiny::checkboxInput("plotSmooth",
                                      shiny::strong("Add Smoothing?"),
+                                     value = FALSE),
+                shiny::checkboxInput("plotCI",
+                                     shiny::strong("Confidence intervals?"),
                                      value = FALSE)
               )
             ),
@@ -572,13 +576,15 @@ exp_shiny <- function(dat,
         rdat() |>
           group_by(dplyr::across(dplyr::all_of(.groups))) |>
           exp_stats(wt = wt, credibility = credibility, expected = ex,
-                    conf_level = conf_level, cred_r = cred_r)
+                    conf_level = conf_level, cred_r = cred_r,
+                    conf_int = TRUE)
       } else {
         rdat() |>
           group_by(dplyr::across(dplyr::all_of(.groups))) |>
           trx_stats(percent_of = input$pct_checks,
                     trx_types = input$trx_types_checks,
-                    combine_trx = input$trx_combine)
+                    combine_trx = input$trx_combine,
+                    conf_int = TRUE)
       }
 
     })
@@ -645,7 +651,8 @@ exp_shiny <- function(dat,
                              second_axis = input$plot2ndY,
                              second_y = !!second_y,
                              second_y_labels = second_y_labels,
-                             y_log10 = input$plotLogY)
+                             y_log10 = input$plotLogY,
+                             conf_int_bars = input$plotCI)
       } else {
 
         facets <- rlang::syms(input$facetVar)

--- a/R/exp_shiny.R
+++ b/R/exp_shiny.R
@@ -436,9 +436,12 @@ exp_shiny <- function(dat,
             shiny::br(),
             shiny::fluidRow(
               shiny::column(
-                width = 4,
+                width = 12,
                 shiny::checkboxInput("tableCI",
                                      shiny::strong("Confidence intervals?"),
+                                     value = FALSE),
+                shiny::checkboxInput("tableCredAdj",
+                                     shiny::strong("Credibility-weighted termination rates?"),
                                      value = FALSE)
               )
             ),
@@ -692,7 +695,13 @@ exp_shiny <- function(dat,
     }, res = 92)
 
     output$xpTable <- gt::render_gt({
-      rxp() |> autotable(conf_int_show = input$tableCI)
+      if (input$study_type == "exp") {
+        rxp() |> autotable(show_conf_int = input$tableCI,
+                           show_cred_adj = input$tableCredAdj)
+      } else {
+        rxp() |> autotable(show_conf_int = input$tableCI)
+      }
+
     })
 
     # filter information

--- a/R/exp_shiny.R
+++ b/R/exp_shiny.R
@@ -124,7 +124,7 @@ exp_shiny <- function(dat,
                       distinct_max = 25L,
                       title,
                       credibility = TRUE,
-                      cred_p = 0.95,
+                      conf_level = 0.95,
                       cred_r = 0.05) {
 
   rlang::check_installed("shiny")
@@ -572,7 +572,7 @@ exp_shiny <- function(dat,
         rdat() |>
           group_by(dplyr::across(dplyr::all_of(.groups))) |>
           exp_stats(wt = wt, credibility = credibility, expected = ex,
-                    cred_p = cred_p, cred_r = cred_r)
+                    conf_level = conf_level, cred_r = cred_r)
       } else {
         rdat() |>
           group_by(dplyr::across(dplyr::all_of(.groups))) |>

--- a/R/exp_shiny.R
+++ b/R/exp_shiny.R
@@ -434,6 +434,14 @@ exp_shiny <- function(dat,
           shiny::tabPanel(
             "Table",
             shiny::br(),
+            shiny::fluidRow(
+              shiny::column(
+                width = 4,
+                shiny::checkboxInput("tableCI",
+                                     shiny::strong("Confidence intervals?"),
+                                     value = FALSE)
+              )
+            ),
             gt::gt_output("xpTable")
           ),
           shiny::tabPanel(
@@ -684,7 +692,7 @@ exp_shiny <- function(dat,
     }, res = 92)
 
     output$xpTable <- gt::render_gt({
-      rxp() |> autotable()
+      rxp() |> autotable(conf_int_show = input$tableCI)
     })
 
     # filter information

--- a/R/exp_stats.R
+++ b/R/exp_stats.R
@@ -56,14 +56,14 @@
 #' @param wt Optional. Length 1 character vector. Name of the column in
 #' `.data` containing weights to use in the calculation of claims,
 #' exposures, partial credibility, and confidence intervals.
-#' @param credibility Whether the output should include partial credibility
+#' @param credibility If `TRUE`, the output will include partial credibility
 #' weights and credibility-weighted termination rates.
 #' @param cred_p Confidence level used for the Limited Fluctuation credibility
 #' method and confidence intervals
 #' @param cred_r Error tolerance under the Limited Fluctuation credibility
 #' method
-#' @param conf_int Whether the output should include confidence intervals around
-#' the observed termination rates and any actual-to-expected ratios.
+#' @param conf_int If `TRUE`, the output will include confidence intervals
+#' around the observed termination rates and any actual-to-expected ratios.
 #' @param object An `exp_df` object
 #' @param ... Groups to retain after `summary()` is called
 #'

--- a/R/exp_stats.R
+++ b/R/exp_stats.R
@@ -38,7 +38,8 @@
 #' `Var(S) = E(N) * Var(X) + E(X)^2 * Var(N)`,
 #'
 #' Where `S` is the aggregate claim random variable, `X` is the weighting
-#' variable, and `N` is a binomial random variable for the number of claims.
+#' variable assumed to follow a normal distribution, and `N` is a binomial
+#' random variable for the number of claims.
 #'
 #' # `summary()` Method
 #'

--- a/R/exp_stats.R
+++ b/R/exp_stats.R
@@ -285,7 +285,7 @@ finish_exp_stats <- function(.data, target_status, expected,
                            "ae_{.col}_lower", expected)
       ae_upper <- exp_form("q_obs_upper / {.col}",
                            "ae_{.col}_upper", expected)
-      ci <- append(ci, ae_lower) |> append(ae_upper)
+      ci <- append(ci, c(ae_lower, ae_upper))
       if (credibility) {
         ci <- append(ci,
                      c(exp_form("credibility * q_obs_lower +

--- a/R/exp_stats.R
+++ b/R/exp_stats.R
@@ -31,15 +31,19 @@
 #' actual-to-expected ratios. The confidence level is dictated
 #' by `conf_level`. If no weighting variable is passed to `wt`, confidence
 #' intervals will be constructed assuming a binomial distribution of claims.
-#' Otherwise, confidence intervals are calculated assuming that the aggregate
-#' claims distribution is normal with a mean equal to observed claims and a
-#' variance equal to:
+#' Otherwise, confidence intervals will be calculated assuming that the
+#' aggregate claims distribution is normal with a mean equal to observed claims
+#' and a variance equal to:
 #'
 #' `Var(S) = E(N) * Var(X) + E(X)^2 * Var(N)`,
 #'
 #' Where `S` is the aggregate claim random variable, `X` is the weighting
 #' variable assumed to follow a normal distribution, and `N` is a binomial
 #' random variable for the number of claims.
+#'
+#' If `credibility` is `TRUE` and expected values are passed to `expected`,
+#' the output will also contain confidence intervals for any
+#' credibility-weighted termination rates.
 #'
 #' # `summary()` Method
 #'
@@ -80,8 +84,11 @@
 #' rates are prefixed by `adj_`.
 #' - If `conf_int` is set to `TRUE`, additional columns are added for lower and
 #' upper confidence interval limits around the observed termination rates and
-#' any actual-to-expected ratios. Confidence interval columns include the name
-#' of the original output column suffixed by either `_lower` or `_upper`.
+#' any actual-to-expected ratios. Additionally, if `credibility` is `TRUE` and
+#' expected values are passed to `expected`, the output will contain confidence
+#' intervals around credibility-weighted termination rates. Confidence interval
+#' columns include the name of the original output column suffixed by either
+#' `_lower` or `_upper`.
 #' - If a value is passed to `wt`, additional columns are created containing
 #' the the sum of weights (`.weight`), the sum of squared weights
 #' (`.weight_qs`), and the number of records (`.weight_n`).

--- a/R/exp_stats.R
+++ b/R/exp_stats.R
@@ -304,7 +304,9 @@ finish_exp_stats <- function(.data, target_status, expected,
                      !!!cred,
                      !!!ci,
                      .groups = "drop") |>
-    relocate(n_exposure, exposure, q_obs, .after = claims)
+    relocate(n_exposure, exposure, q_obs,
+             dplyr::any_of(c("q_obs_lower", "q_obs_upper")),
+             .after = claims)
 
   if (!is.null(wt)) {
     res <- res |>

--- a/R/exp_stats.R
+++ b/R/exp_stats.R
@@ -134,8 +134,7 @@ exp_stats <- function(.data, target_status = attr(.data, "target_status"),
   res <- .data |>
     rename(exposure = {{col_exposure}},
            status = {{col_status}}) |>
-    mutate(n_claims = status %in% target_status,
-           n_exposure = exposure)
+    mutate(n_claims = status %in% target_status)
 
   if (!is.null(wt)) {
     res <- res |>
@@ -281,7 +280,7 @@ finish_exp_stats <- function(.data, target_status, expected,
       ci <- rlang::exprs(
         # For binomial N
         # Var(S) = n * p * (Var(X) + E(X)^2 * (1 - p))
-        sd_agg = (n_exposure * q_obs * (
+        sd_agg = (claims * (
           (ex2_wt - ex_wt ^ 2) + ex_wt ^ 2 * (1 - q_obs))) ^ 0.5,
         q_obs_lower = stats::qnorm(p[[1]], claims, sd_agg) / exposure,
         q_obs_upper = stats::qnorm(p[[2]], claims, sd_agg) / exposure
@@ -313,7 +312,6 @@ finish_exp_stats <- function(.data, target_status, expected,
     dplyr::summarize(n_claims = sum(n_claims),
                      claims = sum(claims),
                      !!!ex_mean,
-                     n_exposure = sum(n_exposure),
                      exposure = sum(exposure),
                      q_obs = claims / exposure,
                      !!!ex_ae,
@@ -321,7 +319,7 @@ finish_exp_stats <- function(.data, target_status, expected,
                      !!!cred,
                      !!!ci,
                      .groups = "drop") |>
-    relocate(n_exposure, exposure, q_obs,
+    relocate(exposure, q_obs,
              dplyr::any_of(c("q_obs_lower", "q_obs_upper")),
              .after = claims)
 

--- a/R/exp_stats.R
+++ b/R/exp_stats.R
@@ -188,13 +188,13 @@ summary.exp_df <- function(object, ...) {
   start_date <- attr(object, "start_date")
   end_date <- attr(object, "end_date")
   expected <- attr(object, "expected")
-  exp_params <- attr(object, "exp_params")
+  xp_params <- attr(object, "xp_params")
   wt <- attr(object, "wt")
 
   finish_exp_stats(res, target_status, expected, .groups,
-                   start_date, end_date, exp_params$credibility,
-                   exp_params$conf_level, exp_params$cred_r,
-                   wt, exp_params$conf_int)
+                   start_date, end_date, xp_params$credibility,
+                   xp_params$conf_level, xp_params$cred_r,
+                   wt, xp_params$conf_int)
 
 }
 
@@ -333,9 +333,9 @@ finish_exp_stats <- function(.data, target_status, expected,
                      expected = expected,
                      end_date = end_date,
                      wt = wt,
-                     exp_params = list(credibility = credibility,
-                                       conf_level = conf_level, cred_r = cred_r,
-                                       conf_int = conf_int))
+                     xp_params = list(credibility = credibility,
+                                      conf_level = conf_level, cred_r = cred_r,
+                                      conf_int = conf_int))
 }
 
 # this function is used to create formula specifications passed to dplyr::mutate

--- a/R/exp_stats.R
+++ b/R/exp_stats.R
@@ -286,6 +286,15 @@ finish_exp_stats <- function(.data, target_status, expected,
       ae_upper <- exp_form("q_obs_upper / {.col}",
                            "ae_{.col}_upper", expected)
       ci <- append(ci, ae_lower) |> append(ae_upper)
+      if (credibility) {
+        ci <- append(ci,
+                     c(exp_form("credibility * q_obs_lower +
+                                (1 - credibility) * {.col}",
+                                "adj_{.col}_lower", expected),
+                       exp_form("credibility * q_obs_upper +
+                                (1 - credibility) * {.col}",
+                                "adj_{.col}_upper", expected)))
+      }
     }
 
   } else {

--- a/R/exp_stats.R
+++ b/R/exp_stats.R
@@ -29,11 +29,11 @@
 #' If `conf_int` is set to `TRUE`, the output will contain lower and upper
 #' confidence interval limits for the observed termination rate and any
 #' actual-to-expected ratios. The confidence level is dictated
-#' by `cred_p`. If no weighting variable is passed to `wt`, confidence intervals
-#' will be constructed assuming a binomial distribution of claims. Otherwise,
-#' confidence intervals are calculated assuming that the aggregate claims
-#' distribution is normal with a mean equal to observed claims and a variance
-#' equal to:
+#' by `conf_level`. If no weighting variable is passed to `wt`, confidence
+#' intervals will be constructed assuming a binomial distribution of claims.
+#' Otherwise, confidence intervals are calculated assuming that the aggregate
+#' claims distribution is normal with a mean equal to observed claims and a
+#' variance equal to:
 #'
 #' `Var(S) = E(N) * Var(X) + E(X)^2 * Var(N)`,
 #'
@@ -58,8 +58,8 @@
 #' exposures, partial credibility, and confidence intervals.
 #' @param credibility If `TRUE`, the output will include partial credibility
 #' weights and credibility-weighted termination rates.
-#' @param cred_p Confidence level used for the Limited Fluctuation credibility
-#' method and confidence intervals
+#' @param conf_level Confidence level used for the Limited Fluctuation
+#' credibility method and confidence intervals
 #' @param cred_r Error tolerance under the Limited Fluctuation credibility
 #' method
 #' @param conf_int If `TRUE`, the output will include confidence intervals
@@ -106,7 +106,7 @@ exp_stats <- function(.data, target_status = attr(.data, "target_status"),
                       col_status = "status",
                       wt = NULL,
                       credibility = FALSE,
-                      cred_p = 0.95, cred_r = 0.05,
+                      conf_level = 0.95, cred_r = 0.05,
                       conf_int = FALSE) {
 
   .groups <- groups(.data)
@@ -144,7 +144,7 @@ exp_stats <- function(.data, target_status = attr(.data, "target_status"),
 
   finish_exp_stats(res, target_status, expected, .groups,
                    start_date, end_date, credibility,
-                   cred_p, cred_r, wt, conf_int)
+                   conf_level, cred_r, wt, conf_int)
 
 }
 
@@ -192,7 +192,7 @@ summary.exp_df <- function(object, ...) {
 
   finish_exp_stats(res, target_status, expected, .groups,
                    start_date, end_date, exp_params$credibility,
-                   exp_params$cred_p, exp_params$cred_r,
+                   exp_params$conf_level, exp_params$cred_r,
                    wt, exp_params$conf_int)
 
 }
@@ -203,7 +203,7 @@ summary.exp_df <- function(object, ...) {
 
 finish_exp_stats <- function(.data, target_status, expected,
                              .groups, start_date, end_date,
-                             credibility, cred_p, cred_r,
+                             credibility, conf_level, cred_r,
                              wt, conf_int) {
 
   # expected value formulas. these are already weighted if applicable
@@ -232,7 +232,7 @@ finish_exp_stats <- function(.data, target_status, expected,
   # credibility formulas - varying by weights
   if (credibility) {
 
-    y <- (stats::qnorm((1 + cred_p) / 2) / cred_r) ^ 2
+    y <- (stats::qnorm((1 + conf_level) / 2) / cred_r) ^ 2
 
     if (is.null(wt)) {
       cred <- rlang::exprs(
@@ -262,7 +262,7 @@ finish_exp_stats <- function(.data, target_status, expected,
   # confidence interval formulas
   if (conf_int) {
 
-    p <- c((1 - cred_p) / 2, 1 - (1 - cred_p) / 2)
+    p <- c((1 - conf_level) / 2, 1 - (1 - conf_level) / 2)
 
     if (is.null(wt)) {
       ci <- rlang::exprs(
@@ -333,7 +333,7 @@ finish_exp_stats <- function(.data, target_status, expected,
                      end_date = end_date,
                      wt = wt,
                      exp_params = list(credibility = credibility,
-                                       cred_p = cred_p, cred_r = cred_r,
+                                       conf_level = conf_level, cred_r = cred_r,
                                        conf_int = conf_int))
 }
 

--- a/R/globals.R
+++ b/R/globals.R
@@ -7,6 +7,6 @@ utils::globalVariables(c("issue_date", "term_date", "last_date",
                          "trx_date", "trx_type", "trx_amt", "trx_n", "trx_flag",
                          "trx_util", "avg_trx", "avg_all", "trx_freq",
                          "class1", "Series", "Rate", "A/E ratio",
-                         "n_exposure", "q_obs_lower", "q_obs_upper",
+                         "q_obs_lower", "q_obs_upper",
                          "trx_util_lower", "trx_util_upper", "sd_agg",
                          "sd_all", "sd_trx", "trx_amt_sq"))

--- a/R/globals.R
+++ b/R/globals.R
@@ -6,4 +6,7 @@ utils::globalVariables(c("issue_date", "term_date", "last_date",
                          "ex_wt", "ex2_wt", "is_number", "n_unique",
                          "trx_date", "trx_type", "trx_amt", "trx_n", "trx_flag",
                          "trx_util", "avg_trx", "avg_all", "trx_freq",
-                         "class1", "Series", "Rate", "A/E ratio"))
+                         "class1", "Series", "Rate", "A/E ratio",
+                         "n_exposure", "q_obs_lower", "q_obs_upper",
+                         "trx_util_lower", "trx_util_upper", "sd_agg",
+                         "sd_all", "sd_trx", "trx_amt_sq"))

--- a/R/plot_special.R
+++ b/R/plot_special.R
@@ -55,10 +55,17 @@ plot_termination_rates <- function(object, ..., include_cred_adj = FALSE) {
 
   if (exp_params$conf_int) {
 
+    extra_piv_cols <- c("q_obs_lower", "q_obs_upper")
+    if (include_cred_adj) {
+      extra_piv_cols <- c(extra_piv_cols,
+                          paste0("adj_", attr(object, "expected"), "_lower"),
+                          paste0("adj_", attr(object, "expected"), "_upper"))
+    }
+
     object <- object |>
       dplyr::rename_at(piv_cols, \(x) paste0(x, "_Rate")) |>
       tidyr::pivot_longer(c(dplyr::all_of(piv_cols |> paste0("_Rate")),
-                            "q_obs_lower", "q_obs_upper"),
+                            extra_piv_cols),
                           names_to = c("Series", ".value"),
                           names_pattern = paste0("^(",
                                                  paste0(piv_cols, collapse = "|"),

--- a/R/plot_special.R
+++ b/R/plot_special.R
@@ -63,7 +63,8 @@ plot_actual_to_expected <- function(object, ..., add_hline = TRUE) {
 
   verify_exp_df(object)
 
-  piv_cols <- paste0("ae_", attr(object, "expected"))
+  piv_cols <- paste0("ae_", attr(object, "expected")) |>
+    intersect(names(object))
   if (length(piv_cols) == 0) {
     rlang::abort(c(x = "The `exp_df` object does not have any actual-to-expected results available.",
                    i = "Hint: to add expected values, use the `expected` argument in `exp_stats()`"

--- a/R/plot_special.R
+++ b/R/plot_special.R
@@ -68,9 +68,10 @@ plot_termination_rates <- function(object, ..., include_cred_adj = FALSE) {
       tidyr::pivot_longer(c(dplyr::all_of(piv_cols |> paste0("_Rate")),
                             dplyr::all_of(extra_piv_cols)),
                           names_to = c("Series", ".value"),
-                          names_pattern = paste0("^(",
-                                                 paste0(piv_cols, collapse = "|"),
-                                                 ")_(Rate|upper|lower)")) |>
+                          names_pattern =
+                            paste0("^(",
+                                   paste0(piv_cols, collapse = "|"),
+                                   ")_(Rate|upper|lower)")) |>
       rename(Rate_lower = lower, Rate_upper = upper)
 
   } else {
@@ -116,9 +117,10 @@ plot_actual_to_expected <- function(object, ..., add_hline = TRUE) {
       tidyr::pivot_longer(c(dplyr::all_of(piv_cols |> paste0("_A/E ratio")),
                             dplyr::all_of(extra_piv_cols)),
                           names_to = c("Series", ".value"),
-                          names_pattern = paste0("^(",
-                                                 paste0(piv_cols, collapse = "|"),
-                                                 ")_(A/E ratio|upper|lower)")) |>
+                          names_pattern =
+                            paste0("^(",
+                                   paste0(piv_cols, collapse = "|"),
+                                   ")_(A/E ratio|upper|lower)")) |>
       rename(`A/E ratio_lower` = lower, `A/E ratio_upper` = upper)
 
   } else {

--- a/R/plot_special.R
+++ b/R/plot_special.R
@@ -47,13 +47,13 @@ plot_termination_rates <- function(object, ..., include_cred_adj = FALSE) {
   verify_exp_df(object)
 
   .groups <- groups(object)
-  exp_params <- attr(object, "exp_params")
+  xp_params <- attr(object, "xp_params")
   piv_cols <- c("q_obs", attr(object, "expected"),
                 if (include_cred_adj) paste0("adj_", attr(object, "expected"))) |>
     intersect(names(object))
 
 
-  if (exp_params$conf_int) {
+  if (xp_params$conf_int) {
 
     extra_piv_cols <- c("q_obs_lower", "q_obs_upper")
     if (include_cred_adj) {
@@ -83,7 +83,7 @@ plot_termination_rates <- function(object, ..., include_cred_adj = FALSE) {
   }
 
   attr(object, "groups") <- append(.groups, rlang::expr(Series), after = 1L)
-  attr(object, "exp_params") <- exp_params
+  attr(object, "xp_params") <- xp_params
   class(object) <- c("exp_df", class(object))
   autoplot(object, y = Rate, ...)
 }
@@ -103,9 +103,9 @@ plot_actual_to_expected <- function(object, ..., add_hline = TRUE) {
   }
 
   .groups <- groups(object)
-  exp_params <- attr(object, "exp_params")
+  xp_params <- attr(object, "xp_params")
 
-  if (exp_params$conf_int) {
+  if (xp_params$conf_int) {
 
     extra_piv_cols <- c(paste0("ae_", attr(object, "expected"), "_lower"),
                         paste0("ae_", attr(object, "expected"), "_upper")) |>
@@ -131,7 +131,7 @@ plot_actual_to_expected <- function(object, ..., add_hline = TRUE) {
   }
 
   attr(object, "groups") <- append(.groups, rlang::expr(Series), after = 1L)
-  attr(object, "exp_params") <- exp_params
+  attr(object, "xp_params") <- xp_params
   class(object) <- c("exp_df", class(object))
   p <- autoplot(object, y = `A/E ratio`, ...)
 

--- a/R/plot_special.R
+++ b/R/plot_special.R
@@ -45,6 +45,10 @@
 plot_termination_rates <- function(object, ..., include_cred_adj = FALSE) {
 
   verify_exp_df(object)
+  if (include_cred_adj && (!attr(object, "xp_params")$credibility ||
+                           is.null(attr(object, "expected")))) {
+    cred_adj_warning()
+  }
 
   .groups <- groups(object)
   piv_cols <- c("q_obs", attr(object, "expected"),
@@ -133,4 +137,11 @@ pivot_plot_special <- function(object, piv_cols, values_to = "Rate") {
   attr(object, "xp_params") <- xp_params
   object
 
+}
+
+# This internal function provides a common warning that is used by multiple
+# functions.
+cred_adj_warning <- function() {
+  rlang::warn(c("*" = "`object` has no credibility-weighted termination rates.",
+                "i" = "Pass `credibility = TRUE` and one or more column names to `expected` when calling `exp_stats()` to calculate credibility-weighted termination rates."))
 }

--- a/R/plot_special.R
+++ b/R/plot_special.R
@@ -47,45 +47,13 @@ plot_termination_rates <- function(object, ..., include_cred_adj = FALSE) {
   verify_exp_df(object)
 
   .groups <- groups(object)
-  xp_params <- attr(object, "xp_params")
   piv_cols <- c("q_obs", attr(object, "expected"),
-                if (include_cred_adj) paste0("adj_", attr(object, "expected"))) |>
-    intersect(names(object))
+                if (include_cred_adj) paste0("adj_", attr(object, "expected")))
 
-
-  if (xp_params$conf_int) {
-
-    extra_piv_cols <- c("q_obs_lower", "q_obs_upper")
-    if (include_cred_adj) {
-      extra_piv_cols <- c(extra_piv_cols,
-                          paste0("adj_", attr(object, "expected"), "_lower"),
-                          paste0("adj_", attr(object, "expected"), "_upper")) |>
-        intersect(names(object))
-    }
-
-    object <- object |>
-      dplyr::rename_at(piv_cols, \(x) paste0(x, "_Rate")) |>
-      tidyr::pivot_longer(c(dplyr::all_of(piv_cols |> paste0("_Rate")),
-                            dplyr::all_of(extra_piv_cols)),
-                          names_to = c("Series", ".value"),
-                          names_pattern =
-                            paste0("^(",
-                                   paste0(piv_cols, collapse = "|"),
-                                   ")_(Rate|upper|lower)")) |>
-      rename(Rate_lower = lower, Rate_upper = upper)
-
-  } else {
-
-    object <- object |>
-      tidyr::pivot_longer(dplyr::all_of(piv_cols),
-                          names_to = "Series",
-                          values_to = "Rate")
-
-  }
+  object <- pivot_plot_special(object, piv_cols)
 
   attr(object, "groups") <- append(.groups, rlang::expr(Series), after = 1L)
-  attr(object, "xp_params") <- xp_params
-  class(object) <- c("exp_df", class(object))
+
   autoplot(object, y = Rate, ...)
 }
 
@@ -95,8 +63,7 @@ plot_actual_to_expected <- function(object, ..., add_hline = TRUE) {
 
   verify_exp_df(object)
 
-  piv_cols <- paste0("ae_", attr(object, "expected")) |>
-    intersect(names(object))
+  piv_cols <- paste0("ae_", attr(object, "expected"))
   if (length(piv_cols) == 0) {
     rlang::abort(c(x = "The `exp_df` object does not have any actual-to-expected results available.",
                    i = "Hint: to add expected values, use the `expected` argument in `exp_stats()`"
@@ -104,37 +71,10 @@ plot_actual_to_expected <- function(object, ..., add_hline = TRUE) {
   }
 
   .groups <- groups(object)
-  xp_params <- attr(object, "xp_params")
 
-  if (xp_params$conf_int) {
-
-    extra_piv_cols <- c(paste0("ae_", attr(object, "expected"), "_lower"),
-                        paste0("ae_", attr(object, "expected"), "_upper")) |>
-      intersect(names(object))
-
-    object <- object |>
-      dplyr::rename_at(piv_cols, \(x) paste0(x, "_A/E ratio")) |>
-      tidyr::pivot_longer(c(dplyr::all_of(piv_cols |> paste0("_A/E ratio")),
-                            dplyr::all_of(extra_piv_cols)),
-                          names_to = c("Series", ".value"),
-                          names_pattern =
-                            paste0("^(",
-                                   paste0(piv_cols, collapse = "|"),
-                                   ")_(A/E ratio|upper|lower)")) |>
-      rename(`A/E ratio_lower` = lower, `A/E ratio_upper` = upper)
-
-  } else {
-
-    object <- object |>
-      tidyr::pivot_longer(dplyr::all_of(piv_cols),
-                          names_to = "Series",
-                          values_to = "A/E ratio")
-
-  }
+  object <- pivot_plot_special(object, piv_cols, values_to = "A/E ratio")
 
   attr(object, "groups") <- append(.groups, rlang::expr(Series), after = 1L)
-  attr(object, "xp_params") <- xp_params
-  class(object) <- c("exp_df", class(object))
   p <- autoplot(object, y = `A/E ratio`, ...)
 
   if (add_hline) {
@@ -143,5 +83,53 @@ plot_actual_to_expected <- function(object, ..., add_hline = TRUE) {
   }
 
   p
+
+}
+
+# this function is used to pivot `exp_df` or `trx_df` objects before they're
+# passed to special plotting functions
+#' @param object An `exp_df` or `trx_df` object
+#' @param piv_cols A primary set of columns to pivot longer
+#' @param extra_piv_cols A secondary set of pivot columns corresponding to the
+#' upper and lower confidence interval limits of the primary set of columns.
+#' These column names must all end in `_upper` or `_lower`.
+#' @param values_to Name of the values column in the pivoted object.
+#' @noRd
+pivot_plot_special <- function(object, piv_cols, values_to = "Rate") {
+
+  hold_class <- class(object)
+  xp_params <- attr(object, "xp_params")
+  piv_cols <- intersect(piv_cols, names(object))
+
+  object <- if (!xp_params$conf_int) {
+    object |>
+      tidyr::pivot_longer(dplyr::all_of(piv_cols),
+                          names_to = "Series",
+                          values_to = values_to)
+  } else {
+
+    extra_piv_cols <- c(
+      piv_cols |> paste0("_upper"),
+      piv_cols |> paste0("_lower")
+    ) |>
+      intersect(names(object))
+
+    object |>
+      dplyr::rename_at(piv_cols, \(x) paste(x, values_to, sep = "_")) |>
+      tidyr::pivot_longer(c(dplyr::all_of(piv_cols |>
+                                            paste(values_to, sep = "_")),
+                            dplyr::all_of(extra_piv_cols)),
+                          names_to = c("Series", ".value"),
+                          names_pattern =
+                            paste0("^(",
+                                   paste0(piv_cols, collapse = "|"),
+                                   ")_(", values_to, "|upper|lower)")) |>
+      dplyr::rename_at(c("lower", "upper"),
+                       \(x) paste(values_to, x, sep = "_"))
+  }
+
+  class(object) <- hold_class
+  attr(object, "xp_params") <- xp_params
+  object
 
 }

--- a/R/plot_special.R
+++ b/R/plot_special.R
@@ -66,7 +66,7 @@ plot_termination_rates <- function(object, ..., include_cred_adj = FALSE) {
     object <- object |>
       dplyr::rename_at(piv_cols, \(x) paste0(x, "_Rate")) |>
       tidyr::pivot_longer(c(dplyr::all_of(piv_cols |> paste0("_Rate")),
-                            extra_piv_cols),
+                            dplyr::all_of(extra_piv_cols)),
                           names_to = c("Series", ".value"),
                           names_pattern = paste0("^(",
                                                  paste0(piv_cols, collapse = "|"),
@@ -114,7 +114,7 @@ plot_actual_to_expected <- function(object, ..., add_hline = TRUE) {
     object <- object |>
       dplyr::rename_at(piv_cols, \(x) paste0(x, "_A/E ratio")) |>
       tidyr::pivot_longer(c(dplyr::all_of(piv_cols |> paste0("_A/E ratio")),
-                            extra_piv_cols),
+                            dplyr::all_of(extra_piv_cols)),
                           names_to = c("Series", ".value"),
                           names_pattern = paste0("^(",
                                                  paste0(piv_cols, collapse = "|"),

--- a/R/plot_special_trx.R
+++ b/R/plot_special_trx.R
@@ -43,36 +43,10 @@ plot_utilization_rates <- function(object, ...) {
   verify_trx_df(object)
 
   .groups <- groups(object)
-  xp_params <- attr(object, "xp_params")
   pct_of <- paste0("pct_of_", attr(object, "percent_of"), "_w_trx")
-  piv_cols <- c("trx_util", pct_of) |>
-    intersect(names(object))
+  piv_cols <- c("trx_util", pct_of)
 
-  if (xp_params$conf_int) {
-
-    extra_piv_cols <- c("trx_util_lower",
-                        "trx_util_upper",
-                        paste0(pct_of, "_lower"),
-                        paste0(pct_of, "_upper")) |>
-      intersect(names(object))
-
-    object <- object |>
-      dplyr::rename_at(piv_cols, \(x) paste0(x, "_Rate")) |>
-      tidyr::pivot_longer(c(dplyr::all_of(piv_cols |> paste0("_Rate")),
-                            dplyr::all_of(extra_piv_cols)),
-                          names_to = c("Series", ".value"),
-                          names_pattern =
-                            paste0("^(",
-                                   paste0(piv_cols, collapse = "|"),
-                                   ")_(Rate|upper|lower)")) |>
-      rename(Rate_lower = lower, Rate_upper = upper)
-
-  } else {
-    object <- object |>
-      tidyr::pivot_longer(dplyr::all_of(piv_cols),
-                          names_to = "Series",
-                          values_to = "Rate")
-  }
+  object <- pivot_plot_special(object, piv_cols)
 
   # special logic to ensure that `Series` will not be used as an
   #   x or color variable
@@ -84,8 +58,6 @@ plot_utilization_rates <- function(object, ...) {
     .groups <- append(.groups, rlang::parse_expr(".no_color"))
   }
   attr(object, "groups") <- c(.groups, rlang::expr(Series))
-  attr(object, "xp_params") <- xp_params
-  class(object) <- c("trx_df", class(object))
 
   autoplot(object, y = Rate, scales = "free_y", ...)
 }

--- a/R/plots.R
+++ b/R/plots.R
@@ -23,7 +23,8 @@
 #' `exposure`.
 #' @param scales The `scales` argument passed to [ggplot2::facet_wrap()].
 #' @param geoms Type of geometry. If "lines" is passed, the plot will
-#' display lines and points. If "bars", the plot will display bars.
+#' display lines and points. If "bars", the plot will display bars. If "points",
+#' the plot will display points only.
 #' @param y_labels Label function passed to [ggplot2::scale_y_continuous()].
 #' @param second_y_labels Same as `y_labels`, but for the second y-axis.
 #' @param y_log10 If `TRUE`, the y-axes are plotted on a log-10 scale.
@@ -63,7 +64,8 @@
 #' @export
 autoplot.exp_df <- function(object, ..., x = NULL, y = NULL, color = NULL,
                             mapping, second_axis = FALSE, second_y = NULL,
-                            scales = "fixed", geoms = c("lines", "bars"),
+                            scales = "fixed",
+                            geoms = c("lines", "bars", "points"),
                             y_labels = scales::label_percent(accuracy = 0.1),
                             second_y_labels = scales::label_comma(
                               accuracy = 1),
@@ -89,7 +91,8 @@ autoplot.exp_df <- function(object, ..., x = NULL, y = NULL, color = NULL,
 #' @export
 autoplot.trx_df <- function(object, ..., x = NULL, y = NULL, color = NULL,
                             mapping, second_axis = FALSE, second_y = NULL,
-                            scales = "fixed", geoms = c("lines", "bars"),
+                            scales = "fixed",
+                            geoms = c("lines", "bars", "points"),
                             y_labels = scales::label_percent(accuracy = 0.1),
                             second_y_labels = scales::label_comma(
                               accuracy = 1),
@@ -122,7 +125,7 @@ plot_experience <- function(
     second_axis = FALSE,
     second_y = NULL,
     scales = "fixed",
-    geoms = c("lines", "bars"),
+    geoms = c("lines", "bars", "points"),
     y_labels = scales::label_percent(accuracy = 0.1),
     second_y_labels = scales::label_comma(accuracy = 1),
     facets,
@@ -195,6 +198,8 @@ plot_experience <- function(
 
   if (geoms == "lines") {
     p <- p + ggplot2::geom_point() + ggplot2::geom_line()
+  } else if (geoms == "points") {
+    p <- p + ggplot2::geom_point()
   } else {
     p <- p + ggplot2::geom_col(position = "dodge")
   }
@@ -216,8 +221,7 @@ plot_experience <- function(
             rlang::syms()
         }
         p <- p + ggplot2::geom_errorbar(ggplot2::aes(
-          ymin = !!y_min_max[[1]], ymax = !!y_min_max[[2]]
-        ))
+          ymin = !!y_min_max[[1]], ymax = !!y_min_max[[2]]))
       }
     } else {
       rlang::warn(c("Confidence intervals are not available for the selected y-variable."))

--- a/R/plots.R
+++ b/R/plots.R
@@ -220,8 +220,7 @@ plot_experience <- function(
     y_min_max <- paste0(y_chr, c("_upper", "_lower"))
 
     if (is.null(conf_int) || !conf_int) {
-      rlang::warn(c("*" = "`object` has no confidence intervals.",
-                    "i" = "Pass `conf_int = TRUE` to `exp_stats()` or `trx_stats()` to calculate confidence intervals."))
+      conf_int_warning()
     } else {
 
       if (all(y_min_max %in% names(object))) {
@@ -237,5 +236,13 @@ plot_experience <- function(
 
   if (is.null(facets)) return(p)
   p + ggplot2::facet_wrap(ggplot2::vars(!!!facets), scales = scales)
+
+}
+
+# This internal function provides a common warning that is used by multiple
+# functions.
+conf_int_warning <- function() {
+  rlang::warn(c("*" = "`object` has no confidence intervals.",
+                "i" = "Pass `conf_int = TRUE` to `exp_stats()` or `trx_stats()` to calculate confidence intervals."))
 
 }

--- a/R/plots.R
+++ b/R/plots.R
@@ -216,20 +216,15 @@ plot_experience <- function(
   if (conf_int_bars) {
 
     y_chr <- rlang::as_name(p$mapping$y)
-    if (y_chr %in% c("q_obs", "Rate", "A/E ratio", "trx_util") ||
-        grepl("^(ae|pct_of)_", y_chr)) {
+    y_min_max <- paste0(y_chr, c("_upper", "_lower"))
+    if (all(y_min_max %in% names(object))) {
 
       conf_int <- attr(object, "xp_params")$conf_int
       if (is.null(conf_int) || !conf_int) {
         rlang::warn(c("*" = "`object` has no confidence intervals.",
-                      "i" = "Pass `conf_int = TRUE` to `exp_stats()` to calculate confidence intervals."))
+                      "i" = "Pass `conf_int = TRUE` to `exp_stats()` or `trx_stats()` to calculate confidence intervals."))
       } else {
-        if (y_chr == "q_obs") {
-          y_min_max <- rlang::exprs(q_obs_lower, q_obs_upper)
-        } else {
-          y_min_max <- paste0(y_chr, c("_upper", "_lower")) |>
-            rlang::syms()
-        }
+        y_min_max <- rlang::syms(y_min_max)
         p <- p + ggplot2::geom_errorbar(ggplot2::aes(
           ymin = !!y_min_max[[1]], ymax = !!y_min_max[[2]]))
       }

--- a/R/plots.R
+++ b/R/plots.R
@@ -28,8 +28,9 @@
 #' @param second_y_labels Same as `y_labels`, but for the second y-axis.
 #' @param y_log10 If `TRUE`, the y-axes are plotted on a log-10 scale.
 #' @param conf_int_bars If `TRUE`, confidence interval error bars are included
-#' in the plot. This option is only available for termination rates and
-#' actual-to-expected ratios.
+#' in the plot. For `exp_df` objects, this option is available for termination
+#' rates and actual-to-expected ratios. For `trx_df` objects, this option is
+#' available for utilization rates and any `pct_of` columns.
 #'
 #' @details If no aesthetic map is supplied, the plot will use the first
 #' grouping variable in `object` on the x axis and `q_obs` on the y
@@ -215,9 +216,10 @@ plot_experience <- function(
   if (conf_int_bars) {
 
     y_chr <- rlang::as_name(p$mapping$y)
-    if (y_chr %in% c("q_obs", "Rate", "A/E ratio") || grepl("^ae_", y_chr)) {
+    if (y_chr %in% c("q_obs", "Rate", "A/E ratio", "trx_util") ||
+        grepl("^(ae|pct_of)_", y_chr)) {
 
-      conf_int <- attr(object, "exp_params")$conf_int
+      conf_int <- attr(object, "xp_params")$conf_int
       if (is.null(conf_int) || !conf_int) {
         rlang::warn(c("*" = "`object` has no confidence intervals.",
                       "i" = "Pass `conf_int = TRUE` to `exp_stats()` to calculate confidence intervals."))

--- a/R/plots.R
+++ b/R/plots.R
@@ -215,7 +215,7 @@ plot_experience <- function(
   if (conf_int_bars) {
 
     y_chr <- rlang::as_name(p$mapping$y)
-    if (y_chr %in% c("q_obs", "Rate") || grepl("^ae_", y_chr)) {
+    if (y_chr %in% c("q_obs", "Rate", "A/E ratio") || grepl("^ae_", y_chr)) {
 
       conf_int <- attr(object, "exp_params")$conf_int
       if (is.null(conf_int) || !conf_int) {

--- a/R/plots.R
+++ b/R/plots.R
@@ -215,7 +215,7 @@ plot_experience <- function(
   if (conf_int_bars) {
 
     y_chr <- rlang::as_name(p$mapping$y)
-    if (y_chr == "q_obs" || grepl("^ae_", y_chr)) {
+    if (y_chr %in% c("q_obs", "Rate") || grepl("^ae_", y_chr)) {
 
       conf_int <- attr(object, "exp_params")$conf_int
       if (is.null(conf_int) || !conf_int) {

--- a/R/plots.R
+++ b/R/plots.R
@@ -244,5 +244,4 @@ plot_experience <- function(
 conf_int_warning <- function() {
   rlang::warn(c("*" = "`object` has no confidence intervals.",
                 "i" = "Pass `conf_int = TRUE` to `exp_stats()` or `trx_stats()` to calculate confidence intervals."))
-
 }

--- a/R/plots.R
+++ b/R/plots.R
@@ -215,21 +215,23 @@ plot_experience <- function(
 
   if (conf_int_bars) {
 
+    conf_int <- attr(object, "xp_params")$conf_int
     y_chr <- rlang::as_name(p$mapping$y)
     y_min_max <- paste0(y_chr, c("_upper", "_lower"))
-    if (all(y_min_max %in% names(object))) {
 
-      conf_int <- attr(object, "xp_params")$conf_int
-      if (is.null(conf_int) || !conf_int) {
-        rlang::warn(c("*" = "`object` has no confidence intervals.",
-                      "i" = "Pass `conf_int = TRUE` to `exp_stats()` or `trx_stats()` to calculate confidence intervals."))
-      } else {
+    if (is.null(conf_int) || !conf_int) {
+      rlang::warn(c("*" = "`object` has no confidence intervals.",
+                    "i" = "Pass `conf_int = TRUE` to `exp_stats()` or `trx_stats()` to calculate confidence intervals."))
+    } else {
+
+      if (all(y_min_max %in% names(object))) {
         y_min_max <- rlang::syms(y_min_max)
         p <- p + ggplot2::geom_errorbar(ggplot2::aes(
           ymin = !!y_min_max[[1]], ymax = !!y_min_max[[2]]))
+
+      } else {
+        rlang::warn(c("Confidence intervals are not available for the selected y-variable."))
       }
-    } else {
-      rlang::warn(c("Confidence intervals are not available for the selected y-variable."))
     }
   }
 

--- a/R/tables.R
+++ b/R/tables.R
@@ -236,8 +236,9 @@ autotable.trx_df <- function(object, fontsize = 100, decimals = 1,
   if (conf_int) {
     tab <- tab |>
       gt::cols_merge_range(trx_util_lower, trx_util_upper) |>
-      gt::cols_label(trx_util_lower = "Utilization CI") |>
-      gt::cols_move(trx_util_lower, after = trx_util)
+      gt::tab_spanner(gt::md("**Utilization**"), c(trx_util, trx_util_lower)) |>
+      gt::cols_label(trx_util = gt::md("*Rate*"),
+                     trx_util_lower = gt::md("*CI*"))
     for (i in percent_of) {
       tab <- tab |>
         gt::cols_merge_range(paste0("pct_of_", i, "_w_trx_lower"),

--- a/R/tables.R
+++ b/R/tables.R
@@ -27,6 +27,8 @@
 #' useful for renaming grouping variables that will appear under their original
 #' variable names if left unchanged. See [gt::cols_label()] for more
 #' information.
+#' @param conf_int_show If `TRUE` confidence intervals will be displayed
+#' assuming they are available on `object`.
 #' @param ... Additional arguments passed to [gt::gt()].
 #'
 #' @details
@@ -74,6 +76,7 @@ autotable.exp_df <- function(object, fontsize = 100, decimals = 1,
                              color_q_obs = "RColorBrewer::GnBu",
                              color_ae_ = "RColorBrewer::RdBu",
                              rename_cols = rlang::list2(...),
+                             conf_int_show = FALSE,
                              ...) {
 
   rlang::check_installed("RColorBrewer")
@@ -83,6 +86,16 @@ autotable.exp_df <- function(object, fontsize = 100, decimals = 1,
   wt <- attr(object, "wt")
   cred <- attr(object, "xp_params")$credibility
   conf_int <- attr(object, "xp_params")$conf_int
+
+
+  if (conf_int_show && !conf_int) {
+    conf_int_warning()
+  } else if (conf_int && !conf_int_show) {
+    object <- object |>
+      select(-dplyr::ends_with("_lower"),
+             -dplyr::ends_with("_upper"))
+  }
+  conf_int <- conf_int_show && conf_int
 
   tab <- object |>
     select(-dplyr::starts_with(".weight")) |>
@@ -188,6 +201,7 @@ autotable.trx_df <- function(object, fontsize = 100, decimals = 1,
                              color_util = "RColorBrewer::GnBu",
                              color_pct_of = "RColorBrewer::RdBu",
                              rename_cols = rlang::list2(...),
+                             conf_int_show = FALSE,
                              ...) {
 
   rlang::check_installed("RColorBrewer")
@@ -195,6 +209,15 @@ autotable.trx_df <- function(object, fontsize = 100, decimals = 1,
   percent_of <- attr(object, "percent_of")
   trx_types <- attr(object, "trx_types")
   conf_int <- attr(object, "xp_params")$conf_int
+
+  if (conf_int_show && !conf_int) {
+    conf_int_warning()
+  } else if (conf_int && !conf_int_show) {
+    object <- object |>
+      select(-dplyr::ends_with("_lower"),
+             -dplyr::ends_with("_upper"))
+  }
+  conf_int <- conf_int_show && conf_int
 
   # remove unnecessary columns
   if (!is.null(percent_of)) {
@@ -255,7 +278,7 @@ autotable.trx_df <- function(object, fontsize = 100, decimals = 1,
   if (colorful) {
 
     pct_of_cols <- c(paste0("pct_of_", percent_of, "_w_trx"),
-                         paste0("pct_of_", percent_of, "_all"))
+                     paste0("pct_of_", percent_of, "_all"))
     domain_pct <- if (!is.null(percent_of)) {
       object |>
         select(dplyr::any_of(pct_of_cols)) |>

--- a/R/tables.R
+++ b/R/tables.R
@@ -100,8 +100,7 @@ autotable.exp_df <- function(object, fontsize = 100, decimals = 1,
   conf_int <- show_conf_int && conf_int
 
   if (show_cred_adj && (!cred | is.null(expected))) {
-    rlang::warn(c("*" = "`object` has no credibility-weighted termination rates.",
-                  "i" = "Pass `credibility = TRUE` and one or more column names to `expected` when calling `exp_stats()` to calculate credibility-weighted termination rates."))
+    cred_adj_warning()
   } else if (cred && !show_cred_adj) {
     object <- object |>
       select(-dplyr::matches(paste0("adj_", expected)))

--- a/R/tables.R
+++ b/R/tables.R
@@ -368,7 +368,8 @@ span_percent_of <- function(tab, pct_of, conf_int) {
   if (conf_int) {
     tab <- tab |>
       gt::cols_label(!!rlang::sym(pct_names[[3]]) := gt::md("*w/ trx CI*"),
-                     !!rlang::sym(pct_names[[4]]) := gt::md("*all CI*"))
+                     !!rlang::sym(pct_names[[4]]) := gt::md("*all CI*")) |>
+      gt::cols_move(pct_names[[3]], pct_names[[1]])
   }
 
   tab

--- a/R/tables.R
+++ b/R/tables.R
@@ -129,8 +129,7 @@ autotable.exp_df <- function(object, fontsize = 100, decimals = 1,
     gt::cols_label(.list = rename_cols) |>
     gt::tab_header(title = "Experience Study Results",
                    subtitle = glue::glue("Target status{ifelse(length(target_status) > 1,'es','')}: {paste(target_status, collapse = ', ')}")) |>
-    gt::tab_source_note(glue::glue("Study range: {as.character(attr(object, 'start_date'))} to {as.character(attr(object, 'end_date'))}")) |>
-    gt::cols_hide(n_exposure)
+    gt::tab_source_note(glue::glue("Study range: {as.character(attr(object, 'start_date'))} to {as.character(attr(object, 'end_date'))}"))
 
   if (length(wt) > 0) {
     tab <- tab |>

--- a/R/tables.R
+++ b/R/tables.R
@@ -80,7 +80,7 @@ autotable.exp_df <- function(object, fontsize = 100, decimals = 1,
   expected <- attr(object, "expected")
   target_status <- attr(object, "target_status")
   wt <- attr(object, "wt")
-  cred <- attr(object, "exp_params")$credibility
+  cred <- attr(object, "xp_params")$credibility
 
   tab <- object |>
     select(-dplyr::starts_with(".weight")) |>

--- a/R/tables.R
+++ b/R/tables.R
@@ -102,7 +102,8 @@ autotable.exp_df <- function(object, fontsize = 100, decimals = 1,
     gt::cols_label(.list = rename_cols) |>
     gt::tab_header(title = "Experience Study Results",
                    subtitle = glue::glue("Target status{ifelse(length(target_status) > 1,'es','')}: {paste(target_status, collapse = ', ')}")) |>
-    gt::tab_source_note(glue::glue("Study range: {as.character(attr(object, 'start_date'))} to {as.character(attr(object, 'end_date'))}"))
+    gt::tab_source_note(glue::glue("Study range: {as.character(attr(object, 'start_date'))} to {as.character(attr(object, 'end_date'))}")) |>
+    gt::cols_hide(n_exposure)
 
   if (length(wt) > 0) {
     tab <- tab |>

--- a/R/tables.R
+++ b/R/tables.R
@@ -51,11 +51,12 @@
 #'     left_join(account_vals, by = c("pol_num", "pol_date_yr"))
 #'
 #'   exp_res <- study_py |> group_by(pol_yr) |>
-#'     exp_stats(expected = c("expected_1", "expected_2"), credibility = TRUE)
+#'     exp_stats(expected = c("expected_1", "expected_2"), credibility = TRUE,
+#'               conf_int = TRUE)
 #'   autotable(exp_res)
 #'
 #'   trx_res <- study_py |> group_by(pol_yr) |>
-#'     trx_stats(percent_of = "av_anniv")
+#'     trx_stats(percent_of = "av_anniv", conf_int = TRUE)
 #'   autotable(trx_res)
 #' }
 #'
@@ -81,12 +82,15 @@ autotable.exp_df <- function(object, fontsize = 100, decimals = 1,
   target_status <- attr(object, "target_status")
   wt <- attr(object, "wt")
   cred <- attr(object, "xp_params")$credibility
+  conf_int <- attr(object, "xp_params")$conf_int
 
   tab <- object |>
     select(-dplyr::starts_with(".weight")) |>
     gt::gt(...) |>
     gt::fmt_number(c(claims, exposure), decimals = 0) |>
     gt::fmt_percent(c(q_obs,
+                      dplyr::ends_with("_lower"),
+                      dplyr::ends_with("_upper"),
                       dplyr::starts_with("ae_"),
                       dplyr::starts_with("adj_"),
                       dplyr::any_of("credibility"),
@@ -113,9 +117,25 @@ autotable.exp_df <- function(object, fontsize = 100, decimals = 1,
     tab <- tab |> gt::cols_hide(n_claims)
   }
 
+  # merge confidence intervals into a single range column
+  if (conf_int) {
+    tab <- tab |>
+      gt::cols_merge_range(q_obs_lower, q_obs_upper) |>
+      gt::cols_label(q_obs_lower = gt::md("*q<sup>obs</sup> CI*"))
+    for (i in expected) {
+      tab <- tab |>
+        gt::cols_merge_range(paste0("ae_", i, "_lower"),
+                             paste0("ae_", i, "_upper"))
+      if (cred) {
+        tab <- tab |>
+          gt::cols_merge_range(paste0("adj_", i, "_lower"),
+                               paste0("adj_", i, "_upper"))
+      }
+    }
+  }
 
   for (i in expected) {
-    tab <- tab |> span_expected(i, cred)
+    tab <- tab |> span_expected(i, cred, conf_int)
   }
 
   if (cred) {
@@ -130,9 +150,10 @@ autotable.exp_df <- function(object, fontsize = 100, decimals = 1,
   }
   if (colorful) {
 
+    ae_cols <- paste0("ae_", expected)
     domain_ae <- if (length(expected > 0)) {
       object |>
-        select(dplyr::starts_with('ae_')) |>
+        select(dplyr::any_of(ae_cols)) |>
         range(na.rm = TRUE)
     }
 
@@ -146,7 +167,7 @@ autotable.exp_df <- function(object, fontsize = 100, decimals = 1,
         )
       ) |>
       gt::data_color(
-        columns = dplyr::starts_with("ae_"),
+        columns = dplyr::any_of(ae_cols),
         fn = scales::col_numeric(
           palette = paletteer::paletteer_d(palette = color_ae_) |>
             as.character(),
@@ -173,6 +194,7 @@ autotable.trx_df <- function(object, fontsize = 100, decimals = 1,
 
   percent_of <- attr(object, "percent_of")
   trx_types <- attr(object, "trx_types")
+  conf_int <- attr(object, "xp_params")$conf_int
 
   # remove unnecessary columns
   if (!is.null(percent_of)) {
@@ -182,13 +204,14 @@ autotable.trx_df <- function(object, fontsize = 100, decimals = 1,
   }
 
   tab <- object |>
-    select(-exposure) |>
+    select(-exposure, -dplyr::any_of("trx_amt_sq")) |>
     arrange(trx_type) |>
     gt::gt(groupname_col = "trx_type") |>
     gt::fmt_number(c(trx_n, trx_amt, trx_flag, avg_trx, avg_all),
                    decimals = 0) |>
     gt::fmt_number(trx_freq, decimals = 1) |>
-    gt::fmt_percent(c(trx_util, dplyr::starts_with("pct_of_")),
+    gt::fmt_percent(c(dplyr::starts_with("trx_util"),
+                      dplyr::starts_with("pct_of_")),
                     decimals = decimals) |>
     gt::sub_missing() |>
     gt::tab_options(table.font.size = gt::pct(fontsize),
@@ -209,15 +232,32 @@ autotable.trx_df <- function(object, fontsize = 100, decimals = 1,
                    subtitle = glue::glue("Transaction type{ifelse(length(trx_types) > 1,'s','')}: {paste(trx_types, collapse = ', ')}")) |>
     gt::tab_source_note(glue::glue("Study range: {as.character(attr(object, 'start_date'))} to {as.character(attr(object, 'end_date'))}"))
 
+  # merge confidence intervals into a single range column
+  if (conf_int) {
+    tab <- tab |>
+      gt::cols_merge_range(trx_util_lower, trx_util_upper) |>
+      gt::cols_label(trx_util_lower = "Utilization CI") |>
+      gt::cols_move(trx_util_lower, after = trx_util)
+    for (i in percent_of) {
+      tab <- tab |>
+        gt::cols_merge_range(paste0("pct_of_", i, "_w_trx_lower"),
+                             paste0("pct_of_", i, "_w_trx_upper")) |>
+        gt::cols_merge_range(paste0("pct_of_", i, "_all_lower"),
+                             paste0("pct_of_", i, "_all_upper"))
+    }
+  }
+
   for (i in percent_of) {
-    tab <- tab |> span_percent_of(i)
+    tab <- tab |> span_percent_of(i, conf_int)
   }
 
   if (colorful) {
 
+    pct_of_cols <- c(paste0("pct_of_", percent_of, "_w_trx"),
+                         paste0("pct_of_", percent_of, "_all"))
     domain_pct <- if (!is.null(percent_of)) {
       object |>
-        select(dplyr::starts_with('pct_of')) |>
+        select(dplyr::any_of(pct_of_cols)) |>
         range(na.rm = TRUE)
     }
 
@@ -231,7 +271,7 @@ autotable.trx_df <- function(object, fontsize = 100, decimals = 1,
         )
       ) |>
       gt::data_color(
-        columns = dplyr::starts_with("pct_of"),
+        columns = dplyr::any_of(pct_of_cols),
         fn = scales::col_numeric(
           palette = paletteer::paletteer_d(palette = color_pct_of) |>
             as.character(),
@@ -246,31 +286,67 @@ autotable.trx_df <- function(object, fontsize = 100, decimals = 1,
 }
 
 
-span_expected <- function(tab, ex, cred) {
+span_expected <- function(tab, ex, cred, conf_int) {
 
   force(ex)
+
+  ae <- paste0("ae_", ex)
+  ae_ci <- paste0(ae, "_lower")
+  adj <- paste0("adj_", ex)
+  adj_ci <- paste0("adj_", ex, "_lower")
+
   tab <- tab |>
     gt::tab_spanner(glue::glue("`{ex}`") |> gt::md(),
-                    c(ex, paste0("ae_", ex),
-                      if (cred) paste0("adj_", ex))) |>
+                    c(ex, ae,
+                      if (cred) adj,
+                      if (conf_int) c(
+                        ae_ci,
+                        if(cred) adj_ci
+                      ))) |>
     gt::cols_label(!!rlang::enquo(ex) := gt::md("*q<sup>exp</sup>*"),
-                   !!rlang::sym(paste0("ae_", ex)) := gt::md("*A/E*"))
+                   !!rlang::sym(ae) := gt::md("*A/E*"))
 
-  if (!cred) return(tab)
+  if (cred) {
+    tab <- tab |> gt::cols_label(
+      !!rlang::sym(adj) := gt::md("*q<sup>adj</sup>*"))
+  }
 
-  tab |> gt::cols_label(
-    !!rlang::sym(paste0("adj_", ex)) := gt::md("*q<sup>adj</sup>*"))
+  if (conf_int) {
+    tab <- tab |> gt::cols_label(
+      !!rlang::sym(ae_ci) :=
+        gt::md("*A/E CI*")) |>
+      gt::cols_move(ae_ci, after = ae)
+    if (cred) {
+      tab <- tab |> gt::cols_label(
+        !!rlang::sym(adj_ci) :=
+          gt::md("*q<sup>adj</sup> CI*"))
+    }
+  }
+
+  tab
 
 }
 
-span_percent_of <- function(tab, pct_of) {
+span_percent_of <- function(tab, pct_of, conf_int) {
 
   pct_names <- paste0("pct_of_", pct_of, c("_w_trx", "_all"))
+  if (conf_int) {
+    pct_names <- c(pct_names,
+                   paste0(pct_names, "_lower"))
+  }
 
   tab <- tab |>
     gt::tab_spanner(glue::glue("**% of {pct_of}**") |> gt::md(),
                     pct_names) |>
     gt::cols_label(!!rlang::sym(pct_names[[1]]) := gt::md("*w/ trx*"),
                    !!rlang::sym(pct_names[[2]]) := gt::md("*all*"))
+
+  if (conf_int) {
+    tab <- tab |>
+      gt::cols_label(!!rlang::sym(pct_names[[3]]) := gt::md("*w/ trx CI*"),
+                     !!rlang::sym(pct_names[[4]]) := gt::md("*all CI*"))
+  }
+
+  tab
 
 }

--- a/R/trx_stats.R
+++ b/R/trx_stats.R
@@ -176,7 +176,7 @@ print.trx_df <- function(x, ...) {
 
   cat("Transaction study results\n\n")
   if (length(groups(x)) > 0) {
-    cat("Groups:", paste(groups(x), collapse = ", "), "\n")
+    cat(" Groups:", paste(groups(x), collapse = ", "), "\n")
   }
   cat(" Study range:", as.character(attr(x, "start_date")), "to",
       as.character(attr(x, "end_date")), "\n",

--- a/R/trx_stats.R
+++ b/R/trx_stats.R
@@ -246,11 +246,11 @@ summary.trx_df <- function(object, ...) {
   start_date <- attr(object, "start_date")
   end_date <- attr(object, "end_date")
   percent_of <- attr(object, "percent_of")
-  trx_params <- attr(object, "trx_params")
+  xp_params <- attr(object, "xp_params")
 
   finish_trx_stats(res, trx_types, percent_of,
                    .groups, start_date, end_date,
-                   trx_params$conf_int, trx_params$conf_level)
+                   xp_params$conf_int, xp_params$conf_level)
 
 }
 
@@ -338,12 +338,12 @@ finish_trx_stats <- function(.data, trx_types, percent_of,
                      !!!ci,
                      .groups = "drop")
 
-    if (conf_int && !is.null(percent_of)) {
-      res <- res |>
-        # drop interim columns
-        select(-sd_trx, -sd_all) |>
-        relocate(trx_amt_sq, .after = dplyr::last_col())
-    }
+  if (conf_int && !is.null(percent_of)) {
+    res <- res |>
+      # drop interim columns
+      select(-sd_trx, -sd_all) |>
+      relocate(trx_amt_sq, .after = dplyr::last_col())
+  }
 
   tibble::new_tibble(res,
                      class = "trx_df",
@@ -351,8 +351,8 @@ finish_trx_stats <- function(.data, trx_types, percent_of,
                      start_date = start_date,
                      percent_of = percent_of,
                      end_date = end_date,
-                     trx_params = list(conf_level = conf_level,
-                                       conf_int = conf_int))
+                     xp_params = list(conf_level = conf_level,
+                                      conf_int = conf_int))
 }
 
 verify_trx_df <- function(.data) {

--- a/R/trx_stats.R
+++ b/R/trx_stats.R
@@ -307,11 +307,11 @@ finish_trx_stats <- function(.data, trx_types, percent_of,
       # confidence intervals across all records
       pct_lower_all <- exp_form(
         "stats::qnorm(p[[1]], trx_amt, sd_all) / {.col}",
-        "pct_of_{.col}_lower",
+        "pct_of_{.col}_all_lower",
         percent_of)
       pct_upper_all = exp_form(
         "stats::qnorm(p[[2]], trx_amt, sd_all) / {.col}",
-        "pct_of_{.col}_upper",
+        "pct_of_{.col}_all_upper",
         percent_of)
       ci <- append(ci, c(sds, pct_lower, pct_upper,
                          pct_lower_all, pct_upper_all))

--- a/R/trx_stats.R
+++ b/R/trx_stats.R
@@ -30,18 +30,6 @@
 #' - In a study of recurring claims, if `percent_of` refers to a column
 #' containing a maximum benefit amount, utilization rates can be determined.
 #'
-#' # Default removal of partial exposures
-#'
-#' As a default, partial exposures are removed from `.data` before summarizing
-#' results. This is done to avoid complexity associated with a lopsided skew
-#' in the timing of transactions. For example, if transactions can occur on a
-#' monthly basis or annually at the beginning of each policy year, partial
-#' exposures may not be appropriate. If a policy had an exposure of 0.5 years
-#' and was taking withdrawals annually at the beginning of the year, an
-#' argument could be made that the exposure should instead be 1 complete year.
-#' If the same policy was expected to take withdrawals 9 months into the year,
-#' it's not clear if the exposure should be 0.5 years or 0.5 / 0.75 years.
-#' To override this treatment, set `full_exposures_only` to `FALSE`.
 #' # Confidence intervals
 #'
 #' If `conf_int` is set to `TRUE`, the output will contain lower and upper
@@ -55,15 +43,28 @@
 #' non-zero transactions (`pct_of_{*}_w_trx`) are constructed using a normal
 #' distribution
 #' - Intervals for transactions as a percentage of another column
-#' regardless of transaction utilization (`pct_of_{*}`) are calculated assuming
-#' that the aggregate distribution is normal with a mean equal to observed
-#' transactions and a variance equal to:
+#' regardless of transaction utilization (`pct_of_{*}_all`) are calculated
+#' assuming that the aggregate distribution is normal with a mean equal to
+#' observed transactions and a variance equal to:
 #'
 #'     `Var(S) = E(N) * Var(X) + E(X)^2 * Var(N)`,
 #'
 #'     Where `S` is the aggregate transactions random variable, `X` is an individual
 #' transaction amount assumed to follow a normal distribution, and `N` is a
 #' binomial random variable for transaction utilization.
+#'
+#' # Default removal of partial exposures
+#'
+#' As a default, partial exposures are removed from `.data` before summarizing
+#' results. This is done to avoid complexity associated with a lopsided skew
+#' in the timing of transactions. For example, if transactions can occur on a
+#' monthly basis or annually at the beginning of each policy year, partial
+#' exposures may not be appropriate. If a policy had an exposure of 0.5 years
+#' and was taking withdrawals annually at the beginning of the year, an
+#' argument could be made that the exposure should instead be 1 complete year.
+#' If the same policy was expected to take withdrawals 9 months into the year,
+#' it's not clear if the exposure should be 0.5 years or 0.5 / 0.75 years.
+#' To override this treatment, set `full_exposures_only` to `FALSE`.
 #'
 #' # `summary()` Method
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -84,7 +84,6 @@ exposed_data <- expose(census_dat, end_date = "2019-12-31",
 exposed_data
 ```
 
-
 Create a summary grouped by policy year and the presence of a guaranteed 
 income rider.
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ exp_res <- exposed_data |>
 exp_res
 #> Experience study results
 #> 
-#> Groups: pol_yr, inc_guar 
+#>  Groups: pol_yr, inc_guar 
 #>  Target status: Surrender 
 #>  Study range: 1900-01-01 to 2019-12-31 
 #> 
@@ -162,7 +162,7 @@ exp_res <- exposed_data |>
 exp_res
 #> Experience study results
 #> 
-#> Groups: pol_yr, inc_guar 
+#>  Groups: pol_yr, inc_guar 
 #>  Target status: Surrender 
 #>  Study range: 1900-01-01 to 2019-12-31 
 #>  Expected values: expected_1, expected_2 
@@ -214,4 +214,3 @@ exp_shiny(exposed_data)
 
 <a href="https://www.freepik.com/free-vector/shine-old-wooden-chest-realistic-composition-transparent-background-with-vintage-coffer-sparkling-particles_7497397.htm#query=treasure&position=7&from_view=search&track=sph">Image
 by macrovector</a> on Freepik
-

--- a/man/autoplot_exp.Rd
+++ b/man/autoplot_exp.Rd
@@ -82,8 +82,9 @@ the plot will display points only.}
 \item{y_log10}{If \code{TRUE}, the y-axes are plotted on a log-10 scale.}
 
 \item{conf_int_bars}{If \code{TRUE}, confidence interval error bars are included
-in the plot. This option is only available for termination rates and
-actual-to-expected ratios.}
+in the plot. For \code{exp_df} objects, this option is available for termination
+rates and actual-to-expected ratios. For \code{trx_df} objects, this option is
+available for utilization rates and any \code{pct_of} columns.}
 }
 \value{
 a \code{ggplot} object

--- a/man/autoplot_exp.Rd
+++ b/man/autoplot_exp.Rd
@@ -19,7 +19,8 @@
   geoms = c("lines", "bars"),
   y_labels = scales::label_percent(accuracy = 0.1),
   second_y_labels = scales::label_comma(accuracy = 1),
-  y_log10 = FALSE
+  y_log10 = FALSE,
+  conf_int_bars = FALSE
 )
 
 \method{autoplot}{trx_df}(
@@ -35,7 +36,8 @@
   geoms = c("lines", "bars"),
   y_labels = scales::label_percent(accuracy = 0.1),
   second_y_labels = scales::label_comma(accuracy = 1),
-  y_log10 = FALSE
+  y_log10 = FALSE,
+  conf_int_bars = FALSE
 )
 }
 \arguments{
@@ -78,6 +80,10 @@ display lines and points. If "bars", the plot will display bars.}
 \item{second_y_labels}{Same as \code{y_labels}, but for the second y-axis.}
 
 \item{y_log10}{If \code{TRUE}, the y-axes are plotted on a log-10 scale.}
+
+\item{conf_int_bars}{If \code{TRUE}, confidence interval error bars are included
+in the plot. This option is only available for termination rates and
+actual-to-expected ratios.}
 }
 \value{
 a \code{ggplot} object

--- a/man/autoplot_exp.Rd
+++ b/man/autoplot_exp.Rd
@@ -16,7 +16,7 @@
   second_axis = FALSE,
   second_y = NULL,
   scales = "fixed",
-  geoms = c("lines", "bars"),
+  geoms = c("lines", "bars", "points"),
   y_labels = scales::label_percent(accuracy = 0.1),
   second_y_labels = scales::label_comma(accuracy = 1),
   y_log10 = FALSE,
@@ -33,7 +33,7 @@
   second_axis = FALSE,
   second_y = NULL,
   scales = "fixed",
-  geoms = c("lines", "bars"),
+  geoms = c("lines", "bars", "points"),
   y_labels = scales::label_percent(accuracy = 0.1),
   second_y_labels = scales::label_comma(accuracy = 1),
   y_log10 = FALSE,
@@ -63,8 +63,7 @@ rate (\code{q_obs}) for \code{exp_df} objects and the observed utilization rate
 
 \item{second_axis}{Logical. If \code{TRUE}, the variable specified by
 \code{second_y} (default = exposure) is plotted on a second
-y-axis. An area geometry is used if the \code{x} variable is numeric. If not,
-bars are plotted.}
+y-axis using an area geometry.}
 
 \item{second_y}{An unquoted column name in \code{object} to use as the \code{y}
 variable on the second y-axis. If unspecified, this will default to
@@ -73,7 +72,8 @@ variable on the second y-axis. If unspecified, this will default to
 \item{scales}{The \code{scales} argument passed to \code{\link[ggplot2:facet_wrap]{ggplot2::facet_wrap()}}.}
 
 \item{geoms}{Type of geometry. If "lines" is passed, the plot will
-display lines and points. If "bars", the plot will display bars.}
+display lines and points. If "bars", the plot will display bars. If "points",
+the plot will display points only.}
 
 \item{y_labels}{Label function passed to \code{\link[ggplot2:scale_continuous]{ggplot2::scale_y_continuous()}}.}
 

--- a/man/autotable.Rd
+++ b/man/autotable.Rd
@@ -16,7 +16,8 @@ autotable(object, ...)
   color_q_obs = "RColorBrewer::GnBu",
   color_ae_ = "RColorBrewer::RdBu",
   rename_cols = rlang::list2(...),
-  conf_int_show = FALSE,
+  show_conf_int = FALSE,
+  show_cred_adj = FALSE,
   ...
 )
 
@@ -28,7 +29,7 @@ autotable(object, ...)
   color_util = "RColorBrewer::GnBu",
   color_pct_of = "RColorBrewer::RdBu",
   rename_cols = rlang::list2(...),
-  conf_int_show = FALSE,
+  show_conf_int = FALSE,
   ...
 )
 }
@@ -57,8 +58,11 @@ useful for renaming grouping variables that will appear under their original
 variable names if left unchanged. See \code{\link[gt:cols_label]{gt::cols_label()}} for more
 information.}
 
-\item{conf_int_show}{If \code{TRUE} confidence intervals will be displayed
+\item{show_conf_int}{If \code{TRUE} confidence intervals will be displayed
 assuming they are available on \code{object}.}
+
+\item{show_cred_adj}{If \code{TRUE} credibility-weighted termination rates will
+be displayed assuming they are available on \code{object}.}
 
 \item{color_util}{Color palette used for utilization rates.}
 

--- a/man/autotable.Rd
+++ b/man/autotable.Rd
@@ -16,6 +16,7 @@ autotable(object, ...)
   color_q_obs = "RColorBrewer::GnBu",
   color_ae_ = "RColorBrewer::RdBu",
   rename_cols = rlang::list2(...),
+  conf_int_show = FALSE,
   ...
 )
 
@@ -27,6 +28,7 @@ autotable(object, ...)
   color_util = "RColorBrewer::GnBu",
   color_pct_of = "RColorBrewer::RdBu",
   rename_cols = rlang::list2(...),
+  conf_int_show = FALSE,
   ...
 )
 }
@@ -54,6 +56,9 @@ can be used to relabel columns on the output table. This parameter is most
 useful for renaming grouping variables that will appear under their original
 variable names if left unchanged. See \code{\link[gt:cols_label]{gt::cols_label()}} for more
 information.}
+
+\item{conf_int_show}{If \code{TRUE} confidence intervals will be displayed
+assuming they are available on \code{object}.}
 
 \item{color_util}{Color palette used for utilization rates.}
 
@@ -92,11 +97,12 @@ if (interactive()) {
     left_join(account_vals, by = c("pol_num", "pol_date_yr"))
 
   exp_res <- study_py |> group_by(pol_yr) |>
-    exp_stats(expected = c("expected_1", "expected_2"), credibility = TRUE)
+    exp_stats(expected = c("expected_1", "expected_2"), credibility = TRUE,
+              conf_int = TRUE)
   autotable(exp_res)
 
   trx_res <- study_py |> group_by(pol_yr) |>
-    trx_stats(percent_of = "av_anniv")
+    trx_stats(percent_of = "av_anniv", conf_int = TRUE)
   autotable(trx_res)
 }
 

--- a/man/exp_shiny.Rd
+++ b/man/exp_shiny.Rd
@@ -34,7 +34,8 @@ a descriptive title will be generated based on attributes of \code{dat}.}
 \item{credibility}{Whether the output should include partial credibility
 weights and credibility-weighted termination rates.}
 
-\item{cred_p}{Confidence level under the Limited Fluctuation credibility method}
+\item{cred_p}{Confidence level used for the Limited Fluctuation credibility
+method and confidence intervals}
 
 \item{cred_r}{Error tolerance under the Limited Fluctuation credibility
 method}

--- a/man/exp_shiny.Rd
+++ b/man/exp_shiny.Rd
@@ -31,7 +31,7 @@ prevents the drawing of overly complex plots. Default value = 25.}
 \item{title}{Optional. Title of the Shiny app. If no title is provided,
 a descriptive title will be generated based on attributes of \code{dat}.}
 
-\item{credibility}{Whether the output should include partial credibility
+\item{credibility}{If \code{TRUE}, the output will include partial credibility
 weights and credibility-weighted termination rates.}
 
 \item{cred_p}{Confidence level used for the Limited Fluctuation credibility

--- a/man/exp_shiny.Rd
+++ b/man/exp_shiny.Rd
@@ -11,7 +11,7 @@ exp_shiny(
   distinct_max = 25L,
   title,
   credibility = TRUE,
-  cred_p = 0.95,
+  conf_level = 0.95,
   cred_r = 0.05
 )
 }
@@ -34,8 +34,8 @@ a descriptive title will be generated based on attributes of \code{dat}.}
 \item{credibility}{If \code{TRUE}, the output will include partial credibility
 weights and credibility-weighted termination rates.}
 
-\item{cred_p}{Confidence level used for the Limited Fluctuation credibility
-method and confidence intervals}
+\item{conf_level}{Confidence level used for the Limited Fluctuation
+credibility method and confidence intervals}
 
 \item{cred_r}{Error tolerance under the Limited Fluctuation credibility
 method}

--- a/man/exp_shiny.Rd
+++ b/man/exp_shiny.Rd
@@ -148,7 +148,8 @@ records retained.
 
 if (interactive()) {
   study_py <- expose_py(census_dat, "2019-12-31", target_status = "Surrender")
-  expected_table <- c(seq(0.005, 0.03, length.out = 10), 0.2, 0.15, rep(0.05, 3))
+  expected_table <- c(seq(0.005, 0.03, length.out = 10),
+                      0.2, 0.15, rep(0.05, 3))
 
   study_py <- study_py |>
     mutate(expected_1 = expected_table[pol_yr],

--- a/man/exp_stats.Rd
+++ b/man/exp_stats.Rd
@@ -112,7 +112,8 @@ variance equal to:
 \code{Var(S) = E(N) * Var(X) + E(X)^2 * Var(N)},
 
 Where \code{S} is the aggregate claim random variable, \code{X} is the weighting
-variable, and \code{N} is a binomial random variable for the number of claims.
+variable assumed to follow a normal distribution, and \code{N} is a binomial
+random variable for the number of claims.
 }
 
 \section{\code{summary()} Method}{

--- a/man/exp_stats.Rd
+++ b/man/exp_stats.Rd
@@ -14,13 +14,15 @@ exp_stats(
   wt = NULL,
   credibility = FALSE,
   cred_p = 0.95,
-  cred_r = 0.05
+  cred_r = 0.05,
+  conf_int = FALSE
 )
 
 \method{summary}{exp_df}(object, ...)
 }
 \arguments{
-\item{.data}{A data frame with exposure-level records, ideally of type \code{exposed_df}}
+\item{.data}{A data frame with exposure-level records, ideally of type
+\code{exposed_df}}
 
 \item{target_status}{A character vector of target status values}
 
@@ -33,15 +35,19 @@ with expected values}
 
 \item{wt}{Optional. Length 1 character vector. Name of the column in
 \code{.data} containing weights to use in the calculation of claims,
-exposures, and partial credibility.}
+exposures, partial credibility, and confidence intervals.}
 
 \item{credibility}{Whether the output should include partial credibility
 weights and credibility-weighted termination rates.}
 
-\item{cred_p}{Confidence level under the Limited Fluctuation credibility method}
+\item{cred_p}{Confidence level used for the Limited Fluctuation credibility
+method and confidence intervals}
 
 \item{cred_r}{Error tolerance under the Limited Fluctuation credibility
 method}
+
+\item{conf_int}{Whether the output should include confidence intervals around
+the observed termination rates and any actual-to-expected ratios.}
 
 \item{object}{An \code{exp_df} object}
 
@@ -49,14 +55,24 @@ method}
 }
 \value{
 A tibble with class \code{exp_df}, \code{tbl_df}, \code{tbl},
-and \code{data.frame}. The results include columns for any grouping
-variables, claims, exposures, and observed termination rates (\code{q_obs}).
-If any values are passed to \code{expected}, additional columns will be
-added for expected termination rates and actual-to-expected ratios. If
-\code{credibility} is set to \code{TRUE}, additional columns are added
+and \code{data.frame}. The results include:
+\itemize{
+\item Columns for any grouping variables, claims, exposures, and observed
+termination rates (\code{q_obs}).
+\item If any values are passed to \code{expected}, additional columns will be
+added for expected termination rates and actual-to-expected ratios.
+\item If \code{credibility} is set to \code{TRUE}, additional columns are added
 for partial credibility and credibility-weighted termination rates
 (assuming values are passed to \code{expected}). Credibility-weighted termination
 rates are prefixed by \code{adj_}.
+\item If \code{conf_int} is set to \code{TRUE}, additional columns are added for lower and
+upper confidence interval limits around the observed termination rates and
+any actual-to-expected ratios. Confidence interval columns include the name
+of the original output column suffixed by either \verb{_lower} or \verb{_upper}.
+\item If a value is passed to \code{wt}, additional columns are created containing
+the the sum of weights (\code{.weight}), the sum of squared weights
+(\code{.weight_qs}), and the number of records (\code{.weight_n}).
+}
 }
 \description{
 Create a summary data frame of termination experience for a
@@ -82,6 +98,22 @@ If \code{credibility} is set to \code{TRUE}, the output will contain a
 \code{credibility} column equal to the partial credibility estimate under
 the Limited Fluctuation credibility method (also known as Classical
 Credibility) assuming a binomial distribution of claims.
+}
+
+\section{Confidence intervals}{
+If \code{conf_int} is set to \code{TRUE}, the output will contain lower and upper
+confidence interval limits for the observed termination rate and any
+actual-to-expected ratio. The confidence level is dictated
+by \code{cred_p}. If no weighting variable is passed to \code{wt}, confidence intervals
+will be constructed assuming a binomial distribution of claims. Otherwise,
+confidence intervals are calculated assuming that the aggregate claims
+distribution is normal with a mean equal to the observed levels of claims
+and a variance equal to:
+
+\verb{Var(S) = E(N) * Var(X) + E(X)^2 * Var(N),}
+
+Where \code{S} is the aggregate claim random variable, \code{X} is the weighting
+variable, and \code{N} is a binomial random variable for the number of claims.
 }
 
 \section{\code{summary()} Method}{

--- a/man/exp_stats.Rd
+++ b/man/exp_stats.Rd
@@ -66,8 +66,11 @@ for partial credibility and credibility-weighted termination rates
 rates are prefixed by \code{adj_}.
 \item If \code{conf_int} is set to \code{TRUE}, additional columns are added for lower and
 upper confidence interval limits around the observed termination rates and
-any actual-to-expected ratios. Confidence interval columns include the name
-of the original output column suffixed by either \verb{_lower} or \verb{_upper}.
+any actual-to-expected ratios. Additionally, if \code{credibility} is \code{TRUE} and
+expected values are passed to \code{expected}, the output will contain confidence
+intervals around credibility-weighted termination rates. Confidence interval
+columns include the name of the original output column suffixed by either
+\verb{_lower} or \verb{_upper}.
 \item If a value is passed to \code{wt}, additional columns are created containing
 the the sum of weights (\code{.weight}), the sum of squared weights
 (\code{.weight_qs}), and the number of records (\code{.weight_n}).
@@ -105,15 +108,19 @@ confidence interval limits for the observed termination rate and any
 actual-to-expected ratios. The confidence level is dictated
 by \code{conf_level}. If no weighting variable is passed to \code{wt}, confidence
 intervals will be constructed assuming a binomial distribution of claims.
-Otherwise, confidence intervals are calculated assuming that the aggregate
-claims distribution is normal with a mean equal to observed claims and a
-variance equal to:
+Otherwise, confidence intervals will be calculated assuming that the
+aggregate claims distribution is normal with a mean equal to observed claims
+and a variance equal to:
 
 \code{Var(S) = E(N) * Var(X) + E(X)^2 * Var(N)},
 
 Where \code{S} is the aggregate claim random variable, \code{X} is the weighting
 variable assumed to follow a normal distribution, and \code{N} is a binomial
 random variable for the number of claims.
+
+If \code{credibility} is \code{TRUE} and expected values are passed to \code{expected},
+the output will also contain confidence intervals for any
+credibility-weighted termination rates.
 }
 
 \section{\code{summary()} Method}{

--- a/man/exp_stats.Rd
+++ b/man/exp_stats.Rd
@@ -37,7 +37,7 @@ with expected values}
 \code{.data} containing weights to use in the calculation of claims,
 exposures, partial credibility, and confidence intervals.}
 
-\item{credibility}{Whether the output should include partial credibility
+\item{credibility}{If \code{TRUE}, the output will include partial credibility
 weights and credibility-weighted termination rates.}
 
 \item{cred_p}{Confidence level used for the Limited Fluctuation credibility
@@ -46,8 +46,8 @@ method and confidence intervals}
 \item{cred_r}{Error tolerance under the Limited Fluctuation credibility
 method}
 
-\item{conf_int}{Whether the output should include confidence intervals around
-the observed termination rates and any actual-to-expected ratios.}
+\item{conf_int}{If \code{TRUE}, the output will include confidence intervals
+around the observed termination rates and any actual-to-expected ratios.}
 
 \item{object}{An \code{exp_df} object}
 

--- a/man/exp_stats.Rd
+++ b/man/exp_stats.Rd
@@ -13,7 +13,7 @@ exp_stats(
   col_status = "status",
   wt = NULL,
   credibility = FALSE,
-  cred_p = 0.95,
+  conf_level = 0.95,
   cred_r = 0.05,
   conf_int = FALSE
 )
@@ -40,8 +40,8 @@ exposures, partial credibility, and confidence intervals.}
 \item{credibility}{If \code{TRUE}, the output will include partial credibility
 weights and credibility-weighted termination rates.}
 
-\item{cred_p}{Confidence level used for the Limited Fluctuation credibility
-method and confidence intervals}
+\item{conf_level}{Confidence level used for the Limited Fluctuation
+credibility method and confidence intervals}
 
 \item{cred_r}{Error tolerance under the Limited Fluctuation credibility
 method}
@@ -103,11 +103,11 @@ Credibility) assuming a binomial distribution of claims.
 If \code{conf_int} is set to \code{TRUE}, the output will contain lower and upper
 confidence interval limits for the observed termination rate and any
 actual-to-expected ratios. The confidence level is dictated
-by \code{cred_p}. If no weighting variable is passed to \code{wt}, confidence intervals
-will be constructed assuming a binomial distribution of claims. Otherwise,
-confidence intervals are calculated assuming that the aggregate claims
-distribution is normal with a mean equal to observed claims and a variance
-equal to:
+by \code{conf_level}. If no weighting variable is passed to \code{wt}, confidence
+intervals will be constructed assuming a binomial distribution of claims.
+Otherwise, confidence intervals are calculated assuming that the aggregate
+claims distribution is normal with a mean equal to observed claims and a
+variance equal to:
 
 \code{Var(S) = E(N) * Var(X) + E(X)^2 * Var(N)},
 

--- a/man/exp_stats.Rd
+++ b/man/exp_stats.Rd
@@ -55,12 +55,11 @@ the observed termination rates and any actual-to-expected ratios.}
 }
 \value{
 A tibble with class \code{exp_df}, \code{tbl_df}, \code{tbl},
-and \code{data.frame}. The results include:
+and \code{data.frame}. The results include columns for any grouping variables,
+claims, exposures, and observed termination rates (\code{q_obs}).
 \itemize{
-\item Columns for any grouping variables, claims, exposures, and observed
-termination rates (\code{q_obs}).
-\item If any values are passed to \code{expected}, additional columns will be
-added for expected termination rates and actual-to-expected ratios.
+\item If any values are passed to \code{expected}, expected termination rates and
+actual-to-expected ratios.
 \item If \code{credibility} is set to \code{TRUE}, additional columns are added
 for partial credibility and credibility-weighted termination rates
 (assuming values are passed to \code{expected}). Credibility-weighted termination
@@ -103,14 +102,14 @@ Credibility) assuming a binomial distribution of claims.
 \section{Confidence intervals}{
 If \code{conf_int} is set to \code{TRUE}, the output will contain lower and upper
 confidence interval limits for the observed termination rate and any
-actual-to-expected ratio. The confidence level is dictated
+actual-to-expected ratios. The confidence level is dictated
 by \code{cred_p}. If no weighting variable is passed to \code{wt}, confidence intervals
 will be constructed assuming a binomial distribution of claims. Otherwise,
 confidence intervals are calculated assuming that the aggregate claims
-distribution is normal with a mean equal to the observed levels of claims
-and a variance equal to:
+distribution is normal with a mean equal to observed claims and a variance
+equal to:
 
-\verb{Var(S) = E(N) * Var(X) + E(X)^2 * Var(N),}
+\code{Var(S) = E(N) * Var(X) + E(X)^2 * Var(N)},
 
 Where \code{S} is the aggregate claim random variable, \code{X} is the weighting
 variable, and \code{N} is a binomial random variable for the number of claims.

--- a/man/trx_stats.Rd
+++ b/man/trx_stats.Rd
@@ -120,19 +120,6 @@ containing a maximum benefit amount, utilization rates can be determined.
 }
 }
 
-\section{Default removal of partial exposures}{
-As a default, partial exposures are removed from \code{.data} before summarizing
-results. This is done to avoid complexity associated with a lopsided skew
-in the timing of transactions. For example, if transactions can occur on a
-monthly basis or annually at the beginning of each policy year, partial
-exposures may not be appropriate. If a policy had an exposure of 0.5 years
-and was taking withdrawals annually at the beginning of the year, an
-argument could be made that the exposure should instead be 1 complete year.
-If the same policy was expected to take withdrawals 9 months into the year,
-it's not clear if the exposure should be 0.5 years or 0.5 / 0.75 years.
-To override this treatment, set \code{full_exposures_only} to \code{FALSE}.
-}
-
 \section{Confidence intervals}{
 If \code{conf_int} is set to \code{TRUE}, the output will contain lower and upper
 confidence interval limits for the observed utilization rate and any
@@ -145,9 +132,9 @@ distribution.
 non-zero transactions (\verb{pct_of_\{*\}_w_trx}) are constructed using a normal
 distribution
 \item Intervals for transactions as a percentage of another column
-regardless of transaction utilization (\verb{pct_of_\{*\}}) are calculated assuming
-that the aggregate distribution is normal with a mean equal to observed
-transactions and a variance equal to:
+regardless of transaction utilization (\verb{pct_of_\{*\}_all}) are calculated
+assuming that the aggregate distribution is normal with a mean equal to
+observed transactions and a variance equal to:
 
 \code{Var(S) = E(N) * Var(X) + E(X)^2 * Var(N)},
 
@@ -155,6 +142,19 @@ Where \code{S} is the aggregate transactions random variable, \code{X} is an ind
 transaction amount assumed to follow a normal distribution, and \code{N} is a
 binomial random variable for transaction utilization.
 }
+}
+
+\section{Default removal of partial exposures}{
+As a default, partial exposures are removed from \code{.data} before summarizing
+results. This is done to avoid complexity associated with a lopsided skew
+in the timing of transactions. For example, if transactions can occur on a
+monthly basis or annually at the beginning of each policy year, partial
+exposures may not be appropriate. If a policy had an exposure of 0.5 years
+and was taking withdrawals annually at the beginning of the year, an
+argument could be made that the exposure should instead be 1 complete year.
+If the same policy was expected to take withdrawals 9 months into the year,
+it's not clear if the exposure should be 0.5 years or 0.5 / 0.75 years.
+To override this treatment, set \code{full_exposures_only} to \code{FALSE}.
 }
 
 \section{\code{summary()} Method}{

--- a/man/trx_stats.Rd
+++ b/man/trx_stats.Rd
@@ -42,7 +42,7 @@ results across all transaction types.}
 be excluded from \code{data}.}
 
 \item{conf_int}{If \code{TRUE}, the output will include confidence intervals
-around the observed utilization rate.}
+around the observed utilization rate and any \code{percent_of} output columns.}
 
 \item{conf_level}{Confidence level for confidence intervals}
 
@@ -71,8 +71,20 @@ If \code{percent_of} is provided, the results will also include:
 These columns include the suffix \verb{_w_trx}.
 \item The sum of any columns passed to \code{percent_of}
 \item \verb{pct_of_\{*\}_w_trx}: total transactions as a percentage of column
-\verb{\{*\}_w_trx}
-\item \verb{pct_of_\{*\}_all}: total transactions as a percentage of column \verb{\{*\}}
+\verb{\{*\}_w_trx}. In other words, total transactions divided by the sum of a
+column including only records utilizing transactions.
+\item \verb{pct_of_\{*\}_all}: total transactions as a percentage of column \verb{\{*\}}. In
+other words, total transactions divided by the sum of a column regardless
+of whether or not transactions were utilized.
+}
+
+If \code{conf_int} is set to \code{TRUE}, additional columns are added for lower and
+upper confidence interval limits around the observed utilization rate and any
+\code{percent_of} output columns. Confidence interval columns include the name
+of the original output column suffixed by either \verb{_lower} or \verb{_upper}.
+\itemize{
+\item If values are passed to \code{percent_of}, an additional column is created
+containing the the sum of squared transaction amounts (\code{trx_amt_sq}).
 }
 }
 \description{
@@ -119,6 +131,30 @@ argument could be made that the exposure should instead be 1 complete year.
 If the same policy was expected to take withdrawals 9 months into the year,
 it's not clear if the exposure should be 0.5 years or 0.5 / 0.75 years.
 To override this treatment, set \code{full_exposures_only} to \code{FALSE}.
+}
+
+\section{Confidence intervals}{
+If \code{conf_int} is set to \code{TRUE}, the output will contain lower and upper
+confidence interval limits for the observed utilization rate and any
+\code{percent_of} output columns. The confidence level is dictated
+by \code{conf_level}.
+\itemize{
+\item Intervals for the utilization rate (\code{trx_util}) assume a binomial
+distribution.
+\item Intervals for transactions as a percentage of another column with
+non-zero transactions (\verb{pct_of_\{*\}_w_trx}) are constructed using a normal
+distribution
+\item Intervals for transactions as a percentage of another column
+regardless of transaction utilization (\verb{pct_of_\{*\}}) are calculated assuming
+that the aggregate distribution is normal with a mean equal to observed
+transactions and a variance equal to:
+
+\code{Var(S) = E(N) * Var(X) + E(X)^2 * Var(N)},
+
+Where \code{S} is the aggregate transactions random variable, \code{X} is an individual
+transaction amount assumed to follow a normal distribution, and \code{N} is a
+binomial random variable for transaction utilization.
+}
 }
 
 \section{\code{summary()} Method}{

--- a/man/trx_stats.Rd
+++ b/man/trx_stats.Rd
@@ -173,6 +173,6 @@ res
 summary(res)
 
 expo |> group_by(inc_guar) |>
-  trx_stats(percent_of = "premium", combine_trx = TRUE)
+  trx_stats(percent_of = "premium", combine_trx = TRUE, conf_int = TRUE)
 
 }

--- a/man/trx_stats.Rd
+++ b/man/trx_stats.Rd
@@ -11,7 +11,9 @@ trx_stats(
   percent_of = NULL,
   combine_trx = FALSE,
   col_exposure = "exposure",
-  full_exposures_only = TRUE
+  full_exposures_only = TRUE,
+  conf_int = FALSE,
+  conf_level = 0.95
 )
 
 \method{summary}{trx_df}(object, ...)
@@ -38,6 +40,11 @@ results across all transaction types.}
 
 \item{full_exposures_only}{If \code{TRUE} (default), partially exposed records will
 be excluded from \code{data}.}
+
+\item{conf_int}{If \code{TRUE}, the output will include confidence intervals
+around the observed utilization rate.}
+
+\item{conf_level}{Confidence level for confidence intervals}
 
 \item{object}{A \code{trx_df} object}
 

--- a/tests/testthat/test-exp_stats.R
+++ b/tests/testthat/test-exp_stats.R
@@ -11,12 +11,12 @@ study_py <- study_py |>
 exp_res <- study_py |>
   group_by(pol_yr, inc_guar) |>
   exp_stats(expected = c("expected_1", "expected_2"),
-            credibility = TRUE)
+            credibility = TRUE, conf_int = TRUE)
 
 exp_res_weighted <- study_py |>
   group_by(pol_yr, inc_guar) |>
   exp_stats(expected = c("expected_1", "expected_2"),
-            credibility = TRUE, wt = "weights")
+            credibility = TRUE, wt = "weights", conf_int = TRUE)
 
 
 test_that("Partial credibility is between 0 and 1", {
@@ -28,10 +28,11 @@ test_that("Partial credibility is between 0 and 1", {
 test_that("Experience study summary method checks", {
   expect_identical(exp_res, summary(exp_res, pol_yr, inc_guar))
   expect_equal(exp_stats(study_py, expected = c("expected_1", "expected_2"),
-                         credibility = TRUE),
+                         credibility = TRUE, conf_int = TRUE),
                summary(exp_res))
   expect_equal(exp_stats(study_py, expected = c("expected_1", "expected_2"),
-                         credibility = TRUE, wt = "weights"),
+                         credibility = TRUE, wt = "weights",
+                         conf_int = TRUE),
                summary(exp_res_weighted))
 })
 
@@ -48,4 +49,19 @@ toy_census2 <- toy_census |> dplyr::rename_with(\(x) renamer[x])
 test_that("Renaming works", {
   expect_error(exp_stats(toy_expo))
   expect_no_error(exp_stats(toy_expo, col_exposure = "a", col_status = "b"))
+})
+
+test_that("Confidence intervals work", {
+  expect_true(all(exp_res$q_obs_lower < exp_res$q_obs))
+  expect_true(all(exp_res$q_obs_upper > exp_res$q_obs))
+  expect_true(all(exp_res_weighted$q_obs_lower < exp_res_weighted$q_obs))
+  expect_true(all(exp_res_weighted$q_obs_upper > exp_res_weighted$q_obs))
+
+  expect_true(all(exp_res$ae_expected_1_lower < exp_res$ae_expected_1))
+  expect_true(all(exp_res$ae_expected_2_upper > exp_res$ae_expected_2))
+  expect_true(all(exp_res_weighted$ae_expected_1_lower <
+                    exp_res_weighted$ae_expected_1))
+  expect_true(all(exp_res_weighted$ae_expected_2_upper >
+                    exp_res_weighted$ae_expected_2))
+
 })

--- a/tests/testthat/test-exp_stats.R
+++ b/tests/testthat/test-exp_stats.R
@@ -24,6 +24,13 @@ test_that("Partial credibility is between 0 and 1", {
   expect_gte(min(exp_res$credibility, exp_res$q_obs), 0)
 })
 
+test_that("Confidence intervals surround the observed surrender rate", {
+  expect_true(all(exp_res$q_obs < exp_res$q_obs_upper))
+  expect_true(all(exp_res$q_obs > exp_res$q_obs_lower))
+  expect_true(all(exp_res_weighted$q_obs < exp_res_weighted$q_obs_upper))
+  expect_true(all(exp_res_weighted$q_obs > exp_res_weighted$q_obs_lower))
+})
+
 
 test_that("Experience study summary method checks", {
   expect_identical(exp_res, summary(exp_res, pol_yr, inc_guar))

--- a/tests/testthat/test-exp_stats.R
+++ b/tests/testthat/test-exp_stats.R
@@ -71,4 +71,12 @@ test_that("Confidence intervals work", {
   expect_true(all(exp_res_weighted$ae_expected_2_upper >
                     exp_res_weighted$ae_expected_2))
 
+  # verify that confidence intervals are tighter using lower confidence
+  less_confident <- study_py |>
+    group_by(pol_yr, inc_guar) |>
+    exp_stats(expected = c("expected_1", "expected_2"),
+              credibility = TRUE, conf_int = TRUE, conf_level = 0.5)
+  expect_true(all(exp_res$q_obs_upper - exp_res$q_obs_lower >
+                    less_confident$q_obs_upper - less_confident$q_obs_lower))
+
 })

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -120,11 +120,11 @@ test_that("Log y scale works", {
                   c("gg", "ggplot"))
 })
 
+no_ci <- expo |> group_by(pol_yr, inc_guar, product) |>
+  exp_stats(expected = "q_exp")
+
 test_that("Confidence interval warning messages work for termination plots", {
   expect_no_warning(autoplot(exp_res4, conf_int_bars = TRUE))
-
-  no_ci <- expo |> group_by(pol_yr, inc_guar, product) |>
-    exp_stats(expected = "q_exp")
   expect_warning(autoplot(no_ci, conf_int_bars = TRUE),
                  regexp = "has no confidence intervals")
   expect_warning(plot_termination_rates(no_ci, conf_int_bars = TRUE),
@@ -139,13 +139,21 @@ test_that("Confidence interval warning messages work for termination plots", {
 test_that("Confidence interval warning messages work for transaction plots", {
   expect_no_warning(autoplot(trx_res4, conf_int_bars = TRUE))
 
-  no_ci <- expo |> group_by(pol_yr, inc_guar, product) |>
+  no_ci_trx <- expo |> group_by(pol_yr, inc_guar, product) |>
     trx_stats(percent_of = "premium")
-  expect_warning(autoplot(no_ci, conf_int_bars = TRUE),
+  expect_warning(autoplot(no_ci_trx, conf_int_bars = TRUE),
                  regexp = "has no confidence intervals")
-  expect_warning(plot_utilization_rates(no_ci, conf_int_bars = TRUE),
+  expect_warning(plot_utilization_rates(no_ci_trx, conf_int_bars = TRUE),
                  regexp = "has no confidence intervals")
-
   expect_warning(autoplot(trx_res4, conf_int_bars = TRUE, y = exposure),
                  regexp = "Confidence intervals are not available")
+})
+
+test_that("plot_termination_rates credibility-adjusted message works", {
+  expect_warning(plot_termination_rates(no_ci, include_cred_adj = TRUE),
+                 regexp = "has no credibility-weighted")
+  no_expected <- expo |> group_by(pol_yr) |>
+    exp_stats(credibility = TRUE)
+  expect_warning(plot_termination_rates(no_expected, include_cred_adj = TRUE),
+                 regexp = "has no credibility-weighted")
 })

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -3,7 +3,7 @@ expo <- expose_py(census_dat, "2019-12-31", target_status = "Surrender") |>
   mutate(q_exp = ifelse(inc_guar, 0.015, 0.03))
 
 exp_stats2 <- function(dat) exp_stats(dat, wt = "premium", credibility = TRUE,
-                                      expected = "q_exp")
+                                      expected = "q_exp", conf_int = TRUE)
 trx_stats2 <- function(dat) trx_stats(dat, percent_of = 'premium')
 
 # ungrouped summaries
@@ -114,4 +114,14 @@ test_that("Log y scale works", {
                   c("gg", "ggplot"))
   expect_s3_class(autoplot(trx_res4, y_log10 = TRUE, second_axis = TRUE),
                   c("gg", "ggplot"))
+})
+
+test_that("Warning messages work", {
+  expect_no_warning(autoplot(exp_res4, conf_int_bars = TRUE))
+  expect_warning(expo |> group_by(pol_yr, inc_guar, product) |>
+                   exp_stats() |>
+                   autoplot(conf_int_bars = TRUE),
+                 regexp = "has no confidence intervals")
+  expect_warning(autoplot(exp_res4, conf_int_bars = TRUE, y = exposure),
+                 regexp = "Confidence intervals are not available")
 })

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -97,6 +97,8 @@ test_that("Termination plots works", {
 
 test_that("AE plots works", {
   expect_s3_class(plot_actual_to_expected(exp_res), c("gg", "ggplot"))
+  expect_s3_class(plot_actual_to_expected(exp_res, conf_int_bars = TRUE),
+                  c("gg", "ggplot"))
   expect_error(plot_actual_to_expected(trx_res), regexp = "must be an `exp_df`")
   expect_error(plot_actual_to_expected(expo |> exp_stats()),
                regexp = "does not have any actual-to-expected")
@@ -121,10 +123,12 @@ test_that("Warning messages work", {
   expect_no_warning(autoplot(exp_res4, conf_int_bars = TRUE))
 
   no_ci <- expo |> group_by(pol_yr, inc_guar, product) |>
-    exp_stats()
+    exp_stats(expected = "q_exp")
   expect_warning(autoplot(no_ci, conf_int_bars = TRUE),
                  regexp = "has no confidence intervals")
   expect_warning(plot_termination_rates(no_ci, conf_int_bars = TRUE),
+                 regexp = "has no confidence intervals")
+  expect_warning(plot_actual_to_expected(no_ci, conf_int_bars = TRUE),
                  regexp = "has no confidence intervals")
 
   expect_warning(autoplot(exp_res4, conf_int_bars = TRUE, y = exposure),

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -4,7 +4,8 @@ expo <- expose_py(census_dat, "2019-12-31", target_status = "Surrender") |>
 
 exp_stats2 <- function(dat) exp_stats(dat, wt = "premium", credibility = TRUE,
                                       expected = "q_exp", conf_int = TRUE)
-trx_stats2 <- function(dat) trx_stats(dat, percent_of = 'premium')
+trx_stats2 <- function(dat) trx_stats(dat, percent_of = 'premium',
+                                      conf_int = TRUE)
 
 # ungrouped summaries
 exp_res <- exp_stats2(expo)
@@ -119,7 +120,7 @@ test_that("Log y scale works", {
                   c("gg", "ggplot"))
 })
 
-test_that("Warning messages work", {
+test_that("Confidence interval warning messages work for termination plots", {
   expect_no_warning(autoplot(exp_res4, conf_int_bars = TRUE))
 
   no_ci <- expo |> group_by(pol_yr, inc_guar, product) |>
@@ -132,5 +133,19 @@ test_that("Warning messages work", {
                  regexp = "has no confidence intervals")
 
   expect_warning(autoplot(exp_res4, conf_int_bars = TRUE, y = exposure),
+                 regexp = "Confidence intervals are not available")
+})
+
+test_that("Confidence interval warning messages work for transaction plots", {
+  expect_no_warning(autoplot(trx_res4, conf_int_bars = TRUE))
+
+  no_ci <- expo |> group_by(pol_yr, inc_guar, product) |>
+    trx_stats(percent_of = "premium")
+  expect_warning(autoplot(no_ci, conf_int_bars = TRUE),
+                 regexp = "has no confidence intervals")
+  expect_warning(plot_utilization_rates(no_ci, conf_int_bars = TRUE),
+                 regexp = "has no confidence intervals")
+
+  expect_warning(autoplot(trx_res4, conf_int_bars = TRUE, y = exposure),
                  regexp = "Confidence intervals are not available")
 })

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -70,6 +70,9 @@ test_that("Autoplot works with mapping overrides", {
                            y_labels = scales::label_number()),
                   c("gg", "ggplot"))
 
+  expect_s3_class(autoplot(exp_res4, geoms = "points"), c("gg", "ggplot"))
+  expect_s3_class(autoplot(trx_res4, geoms = "points"), c("gg", "ggplot"))
+
 })
 
 test_that("Second axis works", {

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -89,7 +89,8 @@ test_that("Second axis works", {
 
 test_that("Termination plots works", {
   expect_s3_class(plot_termination_rates(exp_res), c("gg", "ggplot"))
-  expect_s3_class(plot_termination_rates(exp_res, include_cred_adj = TRUE),
+  expect_s3_class(plot_termination_rates(exp_res, include_cred_adj = TRUE,
+                                         conf_int_bars = TRUE),
                   c("gg", "ggplot"))
   expect_error(plot_termination_rates(trx_res), regexp = "must be an `exp_df`")
 })
@@ -118,10 +119,14 @@ test_that("Log y scale works", {
 
 test_that("Warning messages work", {
   expect_no_warning(autoplot(exp_res4, conf_int_bars = TRUE))
-  expect_warning(expo |> group_by(pol_yr, inc_guar, product) |>
-                   exp_stats() |>
-                   autoplot(conf_int_bars = TRUE),
+
+  no_ci <- expo |> group_by(pol_yr, inc_guar, product) |>
+    exp_stats()
+  expect_warning(autoplot(no_ci, conf_int_bars = TRUE),
                  regexp = "has no confidence intervals")
+  expect_warning(plot_termination_rates(no_ci, conf_int_bars = TRUE),
+                 regexp = "has no confidence intervals")
+
   expect_warning(autoplot(exp_res4, conf_int_bars = TRUE, y = exposure),
                  regexp = "Confidence intervals are not available")
 })

--- a/tests/testthat/test-tables.R
+++ b/tests/testthat/test-tables.R
@@ -6,12 +6,21 @@ expo <- expose_py(census_dat, "2019-12-31", target_status = "Surrender") |>
 exp_res <- expo |> exp_stats()
 trx_res <- expo |> trx_stats()
 exp_res2 <- expo |> exp_stats(wt = "premium", credibility = TRUE,
-                              expected = "q_exp")
-trx_res2 <- expo |> trx_stats(percent_of = 'premium')
+                              expected = "q_exp", conf_int = TRUE)
+trx_res2 <- expo |> trx_stats(percent_of = 'premium', conf_int = TRUE)
 
 test_that("Autotable works", {
   expect_s3_class(autotable(exp_res), c("gt_tbl", "list"))
   expect_s3_class(autotable(trx_res), c("gt_tbl", "list"))
-  expect_s3_class(autotable(exp_res2), c("gt_tbl", "list"))
-  expect_s3_class(autotable(trx_res2), c("gt_tbl", "list"))
+  expect_s3_class(autotable(exp_res2, conf_int_show = TRUE),
+                  c("gt_tbl", "list"))
+  expect_s3_class(autotable(trx_res2, conf_int_show = TRUE),
+                  c("gt_tbl", "list"))
+})
+
+test_that("Table confidence interval warning works", {
+  expect_warning(autotable(exp_res, conf_int_show = TRUE),
+                 regex = "has no confidence intervals")
+  expect_warning(autotable(trx_res, conf_int_show = TRUE),
+                 regex = "has no confidence intervals")
 })

--- a/tests/testthat/test-tables.R
+++ b/tests/testthat/test-tables.R
@@ -12,15 +12,20 @@ trx_res2 <- expo |> trx_stats(percent_of = 'premium', conf_int = TRUE)
 test_that("Autotable works", {
   expect_s3_class(autotable(exp_res), c("gt_tbl", "list"))
   expect_s3_class(autotable(trx_res), c("gt_tbl", "list"))
-  expect_s3_class(autotable(exp_res2, conf_int_show = TRUE),
+  expect_s3_class(autotable(exp_res2, show_conf_int = TRUE),
                   c("gt_tbl", "list"))
-  expect_s3_class(autotable(trx_res2, conf_int_show = TRUE),
+  expect_s3_class(autotable(trx_res2, show_conf_int = TRUE),
                   c("gt_tbl", "list"))
 })
 
 test_that("Table confidence interval warning works", {
-  expect_warning(autotable(exp_res, conf_int_show = TRUE),
+  expect_warning(autotable(exp_res, show_conf_int = TRUE),
                  regex = "has no confidence intervals")
-  expect_warning(autotable(trx_res, conf_int_show = TRUE),
+  expect_warning(autotable(trx_res, show_conf_int = TRUE),
                  regex = "has no confidence intervals")
+})
+
+test_that("Table credibility-weighted termination rates warning works", {
+  expect_warning(autotable(exp_res, show_cred_adj = TRUE),
+                 regex = "has no credibility-weighted")
 })

--- a/tests/testthat/test-trx_stats.R
+++ b/tests/testthat/test-trx_stats.R
@@ -63,8 +63,12 @@ test_that("trx_stats works", {
 
 })
 
-test_that("Confidence intervals surround the observed utilization rate", {
+test_that("Confidence intervals work", {
   res2 <- filter(res, trx_util > 0)
   expect_true(all(res2$trx_util < res2$trx_util_upper))
   expect_true(all(res2$trx_util > res2$trx_util_lower))
+  expect_true(all(res2$pct_of_premium_w_trx < res2$pct_of_premium_w_trx_upper))
+  expect_true(all(res2$pct_of_premium_w_trx > res2$pct_of_premium_w_trx_lower))
+  expect_true(all(res2$pct_of_premium_all < res2$pct_of_premium_all_upper))
+  expect_true(all(res2$pct_of_premium_all > res2$pct_of_premium_all_lower))
 })

--- a/tests/testthat/test-trx_stats.R
+++ b/tests/testthat/test-trx_stats.R
@@ -71,4 +71,15 @@ test_that("Confidence intervals work", {
   expect_true(all(res2$pct_of_premium_w_trx > res2$pct_of_premium_w_trx_lower))
   expect_true(all(res2$pct_of_premium_all < res2$pct_of_premium_all_upper))
   expect_true(all(res2$pct_of_premium_all > res2$pct_of_premium_all_lower))
+
+  # verify that confidence intervals are tighter using lower confidence
+  less_confident <- expo |>
+    group_by(pol_yr, inc_guar) |>
+    trx_stats(percent_of = c("av_anniv", "premium"),
+              conf_int = TRUE, conf_level = 0.5) |>
+    filter(trx_util > 0)
+  expect_true(all(res2$trx_util_upper - res2$trx_util_lower >
+                    less_confident$trx_util_upper -
+                    less_confident$trx_util_lower))
+
 })

--- a/tests/testthat/test-trx_stats.R
+++ b/tests/testthat/test-trx_stats.R
@@ -5,7 +5,8 @@ expo <- expose_py(census_dat, "2019-12-31", target_status = "Surrender") |>
 
 res <- expo |>
   group_by(pol_yr, inc_guar) |>
-  trx_stats(percent_of = c("av_anniv", "premium"))
+  trx_stats(percent_of = c("av_anniv", "premium"),
+            conf_int = TRUE)
 
 test_that("trx_stats error checks work", {
 
@@ -18,7 +19,8 @@ test_that("trx_stats error checks work", {
 
 test_that("Experience study summary method checks", {
   expect_identical(res, summary(res, pol_yr, inc_guar))
-  expect_equal(trx_stats(expo, percent_of = c("av_anniv", "premium")),
+  expect_equal(trx_stats(expo, percent_of = c("av_anniv", "premium"),
+                         conf_int = TRUE),
                summary(res))
 })
 
@@ -32,7 +34,8 @@ test_that("Renaming works", {
 test_that("trx_stats works", {
 
   expect_equal(ncol(expo |> trx_stats(trx_types = "Base",
-                                      percent_of = c("av_anniv", "premium"))),
+                                      percent_of = c("av_anniv", "premium"),
+                                      conf_int = TRUE)),
                ncol(res) - 2)
   expect_s3_class(res, "trx_df")
   expect_true(all(res$exposure >= res$trx_flag, na.rm = TRUE))
@@ -58,4 +61,10 @@ test_that("trx_stats works", {
 
   expect_equal(res2, res3)
 
+})
+
+test_that("Confidence intervals surround the observed utilization rate", {
+  res2 <- filter(res, trx_util > 0)
+  expect_true(all(res2$trx_util < res2$trx_util_upper))
+  expect_true(all(res2$trx_util > res2$trx_util_lower))
 })

--- a/vignettes/actxps.Rmd
+++ b/vignettes/actxps.Rmd
@@ -126,7 +126,7 @@ exp_res
 
 ### `autoplot()` and `autotable()`
 
-The `autoplot()` and `autotable()` functions can be used to create visualizations and summary tables.
+The `autoplot()` and `autotable()` functions can be used to create visualizations and summary tables. See `vignette("visualizations")` for full details on these functions.
 
 ```{r plot, warning=FALSE, message=FALSE, dpi = 300}
 autoplot(exp_res)

--- a/vignettes/articles/visualizations.Rmd
+++ b/vignettes/articles/visualizations.Rmd
@@ -59,7 +59,7 @@ Below, an `exp_df` object is created using `exp_stats()`.
 ```{r plot-data}
 exp_res <- exposed_data |> 
   group_by(pol_yr) |> 
-  exp_stats()
+  exp_stats(conf_int = TRUE)
 ```
 
 The default plot produced by `autoplot.exp_df()` is a line plot of the observed termination rate (`q_obs`). The `x` variable corresponds to the first grouping variable of the `exp_df` object^[If there are no grouping variables, a single point is plotted].
@@ -126,13 +126,13 @@ autoplot(exp_res2, scales = "free_y")
 ```
 
 
-The `geoms` argument can be used to change the plotting geometry. Under the default value of "lines", points and lines are displayed. If "bars" is passed, a bar plot will be drawn.
+The `geoms` argument can be used to change the plotting geometry. Under the default value of "lines", points and lines are displayed. If "bars" is passed, a bar plot will be drawn. If "points" is passed, a scatter plot will be drawn.
 
 ```{r plot-bar}
 autoplot(exp_res, geoms = "bars")
 ```
 
-If the `y_log10` argument is set to `TRUE`, the y-axis will be plotting on a logarithmic base ten scale.
+If the `y_log10` argument is set to `TRUE`, the y-axis will be plotted on a logarithmic base ten scale.
 
 ```{r plot-log10}
 autoplot(exp_res, y_log10 = TRUE)
@@ -147,6 +147,13 @@ autoplot(exp_res, y_log10 = TRUE)
 ```{r plot-second-y-axis}
 autoplot(exp_res, second_axis = TRUE)
 ```
+
+Confidence interval error bars can be added to a plot by passing `conf_int_bars = TRUE`. Confidence intervals will only be displayed if they are available for the selected `y` variable.
+
+```{r plot-conf-int}
+autoplot(exp_res, conf_int_bars = TRUE)
+```
+
 
 ### `plot_termination_rates()`
 
@@ -225,7 +232,6 @@ plot_utilization_rates(trx_res)
 ```
 
 
-
 ## Tables
 
 The `autotable()` function creates summary tables of termination or transaction study results. This function is a generic function with methods specific to `exp_df` and `trx_df` objects. 
@@ -250,6 +256,8 @@ The `autotable()` function creates summary tables of termination or transaction 
   These inputs must be strings referencing a discrete color palette available in the `paletteer` package. Palettes must be in the form "package::palette". For a full list of available palettes, see `paletteer::palettes_d_names`.
   
 - `rename_cols` can be used to relabel columns. This input must be a named list or character vector with names equal to original column names and values equal to the desired column labels. Most of the column names created by `autotable()` are presentation-ready, however, grouping variables on the left side of the table may require updates since they default to the variable names that appear in the data.
+
+- `show_conf_int` and `show_cred_adj` can be used to include any confidence intervals and credibility-weighted termination rates, if available. As a default, these columns are not included to avoid producing overcrowded tables.
 
 ## Interactive Shiny app
 

--- a/vignettes/articles/visualizations.Rmd
+++ b/vignettes/articles/visualizations.Rmd
@@ -271,4 +271,5 @@ The output section includes tabs for plots, tables, and exporting data. The plot
 
 - `distinct_max`: an upper limit on the number of distinct values a variable is allowed to have to be included as a viable option for the color and facets grouping variables. Default = 25.
 - `title`: an optional title for the app
-- `credibility`, `cred_p`, `cred_r`: credibility options for termination studies. See `exp_stats()` for more information. Limited fluctuation credibility estimates at a 95% confidence within 5% of the theoretical mean assuming a binomial distribution are used as a default.
+- `credibility`, `conf_level`, `cred_r`: credibility options for termination studies. See `exp_stats()` for more information. Limited fluctuation credibility estimates at a 95% confidence within 5% of the theoretical mean assuming a binomial distribution are used as a default.
+- The `conf_level` argument is also used for confidence intervals for both termination and transaction studies.

--- a/vignettes/exp_summary.Rmd
+++ b/vignettes/exp_summary.Rmd
@@ -189,12 +189,12 @@ exposed_data2 |>
   select(pol_yr, inc_guar, claims, q_obs, credibility)
 ```
 
-Under the default arguments, credibility calculations assume a 95% confidence of being within 5% of the true value. These parameters can be overridden using the `cred_p` and `cred_r` arguments, respectively.
+Under the default arguments, credibility calculations assume a 95% confidence of being within 5% of the true value. These parameters can be overridden using the `conf_level` and `cred_r` arguments, respectively.
 
 ```{r cred2}
 exposed_data2 |> 
   group_by(pol_yr, inc_guar) |>
-  exp_stats(credibility = TRUE, cred_p = 0.98, cred_r = 0.03) |> 
+  exp_stats(credibility = TRUE, conf_level = 0.98, cred_r = 0.03) |> 
   select(pol_yr, inc_guar, claims, q_obs, credibility)
 ```
 

--- a/vignettes/exp_summary.Rmd
+++ b/vignettes/exp_summary.Rmd
@@ -177,7 +177,6 @@ exposed_data2 |>
 
 ```
 
-
 ## Credibility
 
 If the `credibility` argument is set to `TRUE`, `exp_stats()` will produce an estimate of partial credibility under the Limited Fluctuation credibility method (also known as Classical Credibility) assuming a binomial distribution of claims.^[See Herzog, Thomas (1999). Introduction to Credibility Theory for more information on Limited Fluctuation Credibility.]
@@ -219,6 +218,45 @@ exposed_data2 |>
          expected_1, ae_expected_1)
 ```
 
+
+## Confidence intervals
+
+If `conf_int` is set to `TRUE`, `exp_stats()` will produce lower and upper confidence interval limits for the observed termination rate.
+
+```{r conf1}
+exposed_data2 |> 
+  group_by(pol_yr, inc_guar) |>
+  exp_stats(conf_int = TRUE) |> 
+  select(pol_yr, inc_guar, q_obs, q_obs_lower, q_obs_upper)
+```
+
+If no weighting variable is passed to `wt`, confidence intervals will be constructed assuming a binomial distribution of claims. However, if a weighting variable is supplied, a normal distribution for aggregate claims will be assumed with a mean equal to observed claims and a variance equal to:
+
+$$
+Var(S) = E(N) * Var(X) + E(X)^2 * Var(N)
+$$
+
+Where `S` is the aggregate claim random variable, `X` is the weighting variable assumed to follow a normal distribution, and `N` is a binomial random variable for the number of claims.
+
+The default confidence level is 95%. This can be changed using the `conf_level` argument. Below, tighter confidence intervals are constructed by decreasing the confidence level to 90%.
+
+```{r conf2}
+exposed_data2 |> 
+  group_by(pol_yr, inc_guar) |>
+  exp_stats(conf_int = TRUE, conf_level = 0.9) |> 
+  select(pol_yr, inc_guar, q_obs, q_obs_lower, q_obs_upper)
+```
+
+If expected values are passed to `expected`, the output will also contain confidence intervals around any actual-to-expected ratios. 
+
+```{r conf3}
+exposed_data2 |> 
+  group_by(pol_yr, inc_guar) |>
+  exp_stats(conf_int = TRUE, expected = "expected_1") |> 
+  select(pol_yr, inc_guar, starts_with("ae_"))
+```
+
+Lastly, if `credibility` is `TRUE` *and* expected values are passed to `expected`,  confidence intervals will also be calculated for any credibility-weighted termination rates.
 
 ## Miscellaneous
 

--- a/vignettes/exp_summary.Rmd
+++ b/vignettes/exp_summary.Rmd
@@ -233,7 +233,7 @@ exposed_data2 |>
 If no weighting variable is passed to `wt`, confidence intervals will be constructed assuming a binomial distribution of claims. However, if a weighting variable is supplied, a normal distribution for aggregate claims will be assumed with a mean equal to observed claims and a variance equal to:
 
 $$
-Var(S) = E(N) * Var(X) + E(X)^2 * Var(N)
+Var(S) = E(N) \times Var(X) + E(X)^2 \times Var(N)
 $$
 
 Where `S` is the aggregate claim random variable, `X` is the weighting variable assumed to follow a normal distribution, and `N` is a binomial random variable for the number of claims.

--- a/vignettes/transactions.Rmd
+++ b/vignettes/transactions.Rmd
@@ -163,10 +163,47 @@ glimpse(trx_res)
 
 ```
 
+## Confidence intervals
 
-### `autoplot()` and `autotable()`
+If `conf_int` is set to `TRUE`, `trx_stats()` will produce lower and upper confidence interval limits for the observed utilization rate. Confidence intervals are constructed assuming a binomial distribution.
 
-The `autoplot()` and `autotable()` functions can be used to create visualizations and summary tables from `trx_df` objects.
+```{r trx-conf1}
+exposed_trx |> 
+  group_by(pol_yr) |> 
+  trx_stats(conf_int = TRUE) |> 
+  select(pol_yr, trx_util, trx_util_lower, trx_util_upper)
+```
+
+The default confidence level is 95%. This can be changed using the `conf_level` argument. Below, tighter confidence intervals are constructed by decreasing the confidence level to 90%.
+
+```{r trx-conf2}
+exposed_trx |> 
+  group_by(pol_yr) |> 
+  trx_stats(conf_int = TRUE, conf_level = 0.9) |> 
+  select(pol_yr, trx_util, trx_util_lower, trx_util_upper)
+```
+
+If any column names are passed to `percent_of`, `trx_stats()` will produce additional confidence intervals:
+
+- Intervals for transactions as a percentage of another column when transactions occur (`pct_of_{*}_w_trx`) are constructed using a normal distribution.
+- Intervals for transactions as a percentage of another column regardless of transaction utilization (`pct_of_{*}_all`) are calculated assuming that the aggregate distribution is normal with a mean equal to observed transactions and a variance equal to:
+
+$$
+     Var(S) = E(N) \times Var(X) + E(X)^2 \times Var(N),
+$$
+Where `S` is the aggregate transactions random variable, `X` is an individual transaction amount assumed to follow a normal distribution, and `N` is a binomial random variable for transaction utilization.
+
+```{r trx-conf3}
+exposed_trx_w_av |> 
+  group_by(pol_yr) |> 
+  trx_stats(conf_int = TRUE, percent_of = "av_anniv") |> 
+  select(pol_yr, starts_with("pct_of")) |> 
+  glimpse()
+```
+
+## `autoplot()` and `autotable()`
+
+The `autoplot()` and `autotable()` functions can be used to create visualizations and summary tables from `trx_df` objects. See `vignette("visualizations")` for full details on these functions.
 
 ```{r trx-plot, warning=FALSE, message=FALSE, fig.height=5.5, fig.width=7}
 
@@ -188,7 +225,6 @@ trx_res |>
 ```
 
 <center><img src="../man/figures/trx_gt.png" width="65%" height="65%" /></center>
-
 
 ## Miscellaneous
 


### PR DESCRIPTION
- A new `conf_int` argument was added to `exp_stats()` and that creates confidence 
intervals around observed termination rates, credibility-weighted termination 
rates, and any actual-to-expected ratios.
- Similarly, `conf_int` was added to `trx_stats()` to create confidence intervals around utilization rates and any "percentage of" output columns. A `conf_level`
argument was also added to this function.
- `autoplot.exp_df()` and `autoplot.trx_df()` now have a `conf_int_bars` argument 
that plots confidence intervals (if available) as error bars for the selected 
y-variable
- `autoplot.exp_df()` and `autoplot.trx_df()` can now create scatter plots if
"points" is passed to the `geoms` argument.
- The second y-axis in the `autoplot()` methods was updated to use an area 
geometry instead of bars for discrete x-axis variables. In addition, when a 
log-10 y-scale is used, areas will always be positive quantities. Previously,
it was observed that areas were drawn as negative values for y-values on the 
main scale less than 1.
- `autotable.exp_df()` and `autotable.trx_df()` were updated to format 
intervals.
- **Breaking change** - The confidence level argument `cred_p` was renamed to 
`conf_level`. This change was made because the confidence level is no longer 
strictly used for credibility calculations. This change impacts the functions
`exp_stats()` and `exp_shiny()`.