### PR TITLE
Dev

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: actxps
 Title: Create Actuarial Experience Studies: Prepare Data, Summarize Results, and Create Reports
-Version: 1.4.0.9000
+Version: 1.5.0
 Authors@R: 
     person("Matt", "Heaphy", email = "mattrmattrs@gmail.com", role = c("aut", "cre"))
 Maintainer: Matt Heaphy <mattrmattrs@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,24 @@
-# actxps 1.4.0.9000
+# actxps 1.5.0
 
-- To improve the speed of date calculations, lubridate was replaced with the clock package. Lubridate is no longer included in Imports.
-- **Breaking change** - The `pol_interval()` function is no longer exported. As part of the removal of lubridate, this function's `dur_length` argument only accepts, "year", "quarter", "month", or "week".
+- `expose_split()` bug fixes: 
+
+  - `expose_split()` was updated to respect the values of `start_date` 
+    and `end_date` originally passed to the `expose()` function.
+  - Future policy anniversary dates falling on February 29th leap days are now
+    consistent with `expose()`
+  - New tests were added to verify that the sum of policy year exposures
+    (`exposure_pol`) after calling `expose_split()` match exposures produced by
+    `expose_py()`.
+  
+- The `expose()` family of functions and `add_transactions()` now allow date 
+  columns to be passed as character vectors in YYYY-MM-DD format. Any character 
+  vectors are converted to dates behind-the-scenes, and any missing values will
+  results in an error message. 
+- To improve the speed of date calculations, lubridate was replaced with the 
+  clock package. Lubridate is no longer included in Imports.
+- **Breaking change** - The `pol_interval()` function is no longer exported. 
+  As part of the removal of lubridate, this function's `dur_length` argument 
+  only accepts, "year", "quarter", "month", or "week".
 - Shiny app layout updates
 - Small vignette and documentation clean-ups
 

--- a/R/exp_shiny.R
+++ b/R/exp_shiny.R
@@ -256,10 +256,6 @@ exp_shiny <- function(dat,
     yVar_trx <- NULL
   }
 
-  is.Date <- function(x) {
-    inherits(x, "Date")
-  }
-
   # function to make input widgets
   widget <- function(x,
                      checkbox_limit = 8) {

--- a/R/expose.R
+++ b/R/expose.R
@@ -144,6 +144,12 @@ expose <- function(.data,
     levels(.data$status) <- status_levels
   }
 
+  if (default_status %in% target_status) {
+    rlang::abort(
+      "`default_status` is not allowed to be the same as `target_status`"
+    )
+  }
+
   # pre-exposure updates
   res <- .data |>
     filter(issue_date < end_date,

--- a/R/expose.R
+++ b/R/expose.R
@@ -42,6 +42,8 @@
 #' - `m` = months
 #' - `w` = weeks
 #'
+#' All columns containing dates must be in YYYY-MM-DD format.
+#'
 #' @param .data A data frame with census-level records
 #' @param end_date Experience study end date
 #' @param start_date Experience study start date. Default value = 1900-01-01.
@@ -109,13 +111,26 @@ expose <- function(.data,
   cal_floor <- cal_floor(expo_length)
   add_period <- add_period(expo_length)
 
+  n_term_dates <- sum(!is.na(.data[[col_term_date]]))
+
   # column renames and name conflicts
   .data <- .data |>
     rename(pol_num = {{col_pol_num}},
            status = {{col_status}},
            issue_date = {{col_issue_date}},
            term_date = {{col_term_date}}) |>
-    .expo_name_conflict(cal_expo, expo_length)
+    .expo_name_conflict(cal_expo, expo_length) |>
+    # convert to dates if needed
+    mutate(dplyr::across(c(issue_date, term_date), .convert_date))
+
+  .check_missing_dates(.data$issue_date, "issue_date")
+
+  if (n_term_dates != sum(!is.na(.data$term_date))) {
+    rlang::abort(c(
+      "Bad termination date formats were detected.",
+      i = "Make sure all dates are in YYYY-MM-DD format.")
+    )
+  }
 
   # set up statuses
   if (!is.factor(.data$status)) .data$status <- factor(.data$status)
@@ -368,4 +383,22 @@ abbr_period <- function(x) {
 most_common <- function(x) {
   y <- table(x) |> sort(decreasing = TRUE) |> names()
   factor(y[[1]], levels(x))
+}
+
+is.Date <- function(x) {
+  inherits(x, "Date")
+}
+
+.convert_date <- function(x) {
+  if (is.Date(x)) return(x)
+  clock::date_parse(x, format = "%Y-%m-%d")
+}
+
+.check_missing_dates <- function(x, name) {
+  if (any(is.na(x))) {
+    rlang::abort(c(
+      glue::glue("Missing values are not allowed in the `{name}` column."),
+      i = "Make sure all dates are in YYYY-MM-DD format.")
+    )
+  }
 }

--- a/R/expose_split.R
+++ b/R/expose_split.R
@@ -60,15 +60,12 @@ expose_split <- function(.data) {
   target_status <- attr(.data, "target_status")
   default_status <- attr(.data, "default_status")
   date_cols <- attr(.data, "date_cols") |> rlang::parse_exprs()
+  start_date <- attr(.data, "start_date")
+  end_date <- attr(.data, "end_date")
   expo_length <- expo_type[[2]]
 
-  pol_frac <- function(x, start, end, y) {
-    if (missing(y)) {
-      as.integer(x - start + 1) / as.integer(end - start + 1)
-    } else {
-      as.integer(x - y) / as.integer(end - start + 1)
-    }
-
+  pol_frac <- function(x, start, end, y = start - 1) {
+    as.integer(x - y) / as.integer(end - start + 1)
   }
   cal_frac <- cal_frac(expo_length)
 
@@ -76,8 +73,10 @@ expose_split <- function(.data) {
   add_years <- \(x, n) clock::add_years(x, n, invalid = "previous")
 
   # time fractions
-  # h = yearfrac from boy to anniv
-  # v = yearfrac from boy to term
+  # b = fraction from boy to cal_b
+  #     - usually zero except for new contracts and a truncated start date
+  # h = fraction from boy to anniv
+  # v = fraction from boy to the earlier of termination and cal_e
 
   .data <- .data |>
     # temporary generic date column names
@@ -88,25 +87,28 @@ expose_split <- function(.data) {
         issue_date,
         clock::get_year(cal_b) - clock::get_year(issue_date)),
       split = between(anniv, cal_b, cal_e),
-      h = cal_frac(anniv, 1),
-      v = cal_frac(term_date)
+      cal_b = pmax(start_date, issue_date, cal_b),
+      cal_e = pmin(end_date, cal_e),
+      b = cal_frac(cal_b, 1),
+      h = dplyr::if_else(split, cal_frac(anniv, 1), 0),
+      v = dplyr::if_else(is.na(term_date), cal_e, term_date) |> cal_frac()
     )
 
   pre_anniv <- .data |>
     filter(split) |>
     mutate(piece = 1L,
-           cal_b = pmax(issue_date, cal_b),
-           cal_e = anniv - 1,
-           exposure = h,
-           exposure_pol = 1 - pol_frac(cal_b - 1L,
-                                       add_years(anniv, -1),
-                                       anniv - 1L)
+           cal_e = pmin(end_date, anniv - 1),
+           exposure = pmin(h, v) - b,
+           exposure_pol = pol_frac(cal_e,
+                                   add_years(anniv, -1),
+                                   anniv - 1L,
+                                   cal_b - 1L)
     )
 
   post_anniv <- .data |>
     mutate(piece = 2L,
-           cal_b = dplyr::if_else(split, anniv, cal_b),
-           exposure = dplyr::if_else(split, 1 - h, 1),
+           cal_b = dplyr::if_else(split, pmax(anniv, start_date), cal_b),
+           exposure = v - pmax(h, b),
            anniv = dplyr::if_else(anniv > cal_e,
                                   add_years(anniv, -1),
                                   anniv),
@@ -129,11 +131,12 @@ expose_split <- function(.data) {
                                    status),
            claims = status %in% target_status,
            exposure_cal = dplyr::case_when(
-             claims ~ dplyr::if_else(piece == 1 | cal_b == issue_date,
-                                     1, 1 - h),
+             claims ~ dplyr::if_else(piece == 1 | cal_b == issue_date |
+                                       cal_b == start_date,
+                                     1, 1 - (h - b)),
              is.na(term_date) ~ exposure,
-             piece == 1 ~ v,
-             .default = v - h
+             piece == 1 ~ v - b,
+             .default = v - pmax(h, b)
            ),
            exposure_pol = dplyr::case_when(
              claims ~ dplyr::case_when(
@@ -153,7 +156,7 @@ expose_split <- function(.data) {
            )
     ) |>
     arrange(pol_num, cal_b, piece) |>
-    select(-h, -v, -split, -anniv, -claims, -exposure, -piece) |>
+    select(-b, -h, -v, -split, -anniv, -claims, -exposure, -piece) |>
     relocate(pol_yr, .after = cal_e) |>
     # restore date column names
     rename(!!date_cols[[1]] := cal_b,

--- a/R/globals.R
+++ b/R/globals.R
@@ -12,4 +12,4 @@ utils::globalVariables(c("issue_date", "term_date", "last_date",
                          "sd_all", "sd_trx", "trx_amt_sq",
                          "n", "name", "ymax", "ymin",
                          "cal_yr", "anniv", "cal_yr_end", "h", "piece", "v",
-                         "scope", "next_anniv"))
+                         "scope", "next_anniv", "b"))

--- a/R/globals.R
+++ b/R/globals.R
@@ -12,4 +12,4 @@ utils::globalVariables(c("issue_date", "term_date", "last_date",
                          "sd_all", "sd_trx", "trx_amt_sq",
                          "n", "name", "ymax", "ymin",
                          "cal_yr", "anniv", "cal_yr_end", "h", "piece", "v",
-                         "scope"))
+                         "scope", "next_anniv"))

--- a/R/transactions.R
+++ b/R/transactions.R
@@ -12,6 +12,8 @@
 #' Transactions are associated with the `exposed_df` object by matching
 #' transactions dates with exposure dates ranges found in `exposed_df`.
 #'
+#' All columns containing dates must be in YYYY-MM-DD format.
+#'
 #' @param .data A data frame with exposure-level records with the class
 #' `exposed_df`. Use [as_exposed_df()] to convert a data frame to an
 #' `exposed_df` object if necessary.
@@ -64,8 +66,10 @@ add_transactions <- function(.data, trx_data,
     rename(pol_num = {{col_pol_num}},
            trx_date = {{col_trx_date}},
            trx_type = {{col_trx_type}},
-           trx_amt = {{col_trx_amt}})
+           trx_amt = {{col_trx_amt}}) |>
+    mutate(trx_date = .convert_date(trx_date))
 
+  .check_missing_dates(trx_data$trx_date, "trx_date")
 
   # check for conflicting transaction types
   existing_trx_types <- attr(.data, "trx_types")

--- a/man/add_transactions.Rd
+++ b/man/add_transactions.Rd
@@ -53,6 +53,8 @@ for each transaction type. These columns have names of the pattern
 
 Transactions are associated with the \code{exposed_df} object by matching
 transactions dates with exposure dates ranges found in \code{exposed_df}.
+
+All columns containing dates must be in YYYY-MM-DD format.
 }
 \examples{
 expo <- expose_py(census_dat, "2019-12-31", target_status = "Surrender")

--- a/man/expose.Rd
+++ b/man/expose.Rd
@@ -127,6 +127,8 @@ For exposure periods:
 \item \code{m} = months
 \item \code{w} = weeks
 }
+
+All columns containing dates must be in YYYY-MM-DD format.
 }
 
 \examples{

--- a/tests/testthat/test-expose.R
+++ b/tests/testthat/test-expose.R
@@ -133,6 +133,20 @@ test_that("expose_split() is consistent with expose_cy()", {
                sum(study_split$trx_amt_Base))
   expect_equal(sum(study_cy$trx_amt_Rider),
                sum(study_split$trx_amt_Rider))
+  expect_true(all(between(study_split$exposure_cal, 0, 1)))
+  expect_true(all(between(study_split$exposure_pol, 0, 1)))
+})
+
+study_cy2 <- expose_cq(census_dat, "2019-02-27", target_status = "Surrender",
+                      start_date = "2010-06-15")
+study_split2 <- expose_split(study_cy2)
+
+test_that("expose_split() is consistent with expose_cy() when using atypical start and end dates", {
+  expect_equal(sum(study_cy2$exposure), sum(study_split2$exposure_cal))
+  expect_equal(sum(study_cy2$status != "Active"),
+               sum(study_split2$status != "Active"))
+  expect_true(all(between(study_split2$exposure_cal, 0, 1)))
+  expect_true(all(between(study_split2$exposure_pol, 0, 1)))
 })
 
 test_that("expose_split() warns about transactions attached too early", {

--- a/tests/testthat/test-expose.R
+++ b/tests/testthat/test-expose.R
@@ -112,6 +112,13 @@ test_that("Renaming and name conflict warnings work", {
   expect_warning(expose_cy(toy_census |> mutate(cal_yr_end = 1), "2020-12-31"))
 })
 
+test_that("Date format checks work", {
+  toy_census3 <- toy_census
+  toy_census3$issue_date[[1]] <- NA
+  expect_error(expose_py(toy_census3, "2020-12-31"),
+               regexp = "Missing values are not allowed in the `issue_date`")
+})
+
 # split exposure tests
 
 test_that("expose_split() fails when passed non-calendar exposures", {

--- a/tests/testthat/test-expose.R
+++ b/tests/testthat/test-expose.R
@@ -47,7 +47,7 @@ test_that("Period start and end dates roll", {
 leap_day <- data.frame(pol_num = 1L,
                        status = 'Active',
                        issue_date = as.Date("2020-02-29"),
-                       term_date = NA)
+                       term_date = NA_character_)
 
 leap_expose <- expose_pm(leap_day, end_date = "2021-02-28")
 
@@ -56,7 +56,7 @@ leap_expose <- expose_pm(leap_day, end_date = "2021-02-28")
 march_1 <- data.frame(pol_num = 1L,
                       status = 'Active',
                       issue_date = as.Date("2019-03-01"),
-                      term_date = NA)
+                      term_date = NA_character_)
 march_1_expose <- expose_pm(march_1, end_date = "2020-02-29")
 
 
@@ -125,6 +125,19 @@ test_that("expose_split() fails when passed non-calendar exposures", {
 study_split <- expose_split(study_cy) |> add_transactions(withdrawals)
 study_cy <- add_transactions(study_cy, withdrawals)
 
+py_sum_check <- function(py, split) {
+  py_sums <- py |>
+    dplyr::summarize(exposure = sum(exposure),
+                     .by = c(pol_num, pol_yr))
+  split_sums <- split |>
+    dplyr::summarize(exposure_pol = sum(exposure_pol),
+                     .by = c(pol_num, pol_yr))
+  py_sums |> inner_join(split_sums, by = c("pol_num", "pol_yr"),
+                        relationship = "one-to-one") |>
+    filter(!dplyr::near(exposure, exposure_pol)) |>
+    nrow()
+}
+
 test_that("expose_split() is consistent with expose_cy()", {
   expect_equal(sum(study_cy$exposure), sum(study_split$exposure_cal))
   expect_equal(sum(study_cy$status != "Active"),
@@ -135,18 +148,61 @@ test_that("expose_split() is consistent with expose_cy()", {
                sum(study_split$trx_amt_Rider))
   expect_true(all(between(study_split$exposure_cal, 0, 1)))
   expect_true(all(between(study_split$exposure_pol, 0, 1)))
+  expect_equal(py_sum_check(study_py, study_split), 0)
+
 })
 
+study_py2 <- expose_py(census_dat, "2019-02-27", target_status = "Surrender",
+                       start_date = "2010-06-15")
 study_cy2 <- expose_cq(census_dat, "2019-02-27", target_status = "Surrender",
-                      start_date = "2010-06-15")
+                       start_date = "2010-06-15")
 study_split2 <- expose_split(study_cy2)
 
-test_that("expose_split() is consistent with expose_cy() when using atypical start and end dates", {
-  expect_equal(sum(study_cy2$exposure), sum(study_split2$exposure_cal))
-  expect_equal(sum(study_cy2$status != "Active"),
-               sum(study_split2$status != "Active"))
-  expect_true(all(between(study_split2$exposure_cal, 0, 1)))
-  expect_true(all(between(study_split2$exposure_pol, 0, 1)))
+test_that(
+  paste0("expose_split() is consistent with expose_cy() when using ",
+         "atypical start and end dates"),
+  {
+    expect_equal(sum(study_cy2$exposure), sum(study_split2$exposure_cal))
+    expect_equal(sum(study_cy2$status != "Active"),
+                 sum(study_split2$status != "Active"))
+    expect_true(all(between(study_split2$exposure_cal, 0, 1)))
+    expect_true(all(between(study_split2$exposure_pol, 0, 1)))
+    expect_equal(py_sum_check(study_py2, study_split2), 0)
+  })
+
+# odd census
+odd_census <- dplyr::tribble(
+  ~pol_num, ~status, ~issue_date, ~term_date,
+  # death in first month
+  "D1", "Death", "2022-04-15", "2022-04-25",
+  # death in first year
+  "D2", "Death", "2022-04-15", "2022-09-25",
+  # death after 18 months
+  "D3", "Death", "2022-04-15", "2023-09-25",
+  # surrender in first month
+  "S1", "Surrender", "2022-11-10", "2022-11-20",
+  # surrender in first year
+  "S2", "Surrender", "2022-11-10", "2023-3-20",
+  # surrender after 18 months
+  "S3", "Surrender", "2022-11-10", "2024-3-20",
+  # active
+  "A", "Active", "2022-6-20", NA
+)
+
+odd_study <- expose_cm(odd_census, "2024-05-19", target_status = "Surrender",
+                       default_status = "Active", start_date = "2022-04-10")
+odd_py <- expose_py(odd_census, "2024-05-19", target_status = "Surrender",
+                    default_status = "Active", start_date = "2022-04-10")
+odd_split <- expose_split(odd_study)
+
+test_that("expose_split() checks with odd dates", {
+  expect_equal(sum(odd_study$exposure), sum(odd_split$exposure_cal))
+  expect_equal(sum(odd_study$status != "Active"),
+               sum(odd_split$status != "Active"))
+  expect_true(all(between(odd_split$exposure_cal, 0, 1)))
+  expect_true(all(between(odd_split$exposure_pol, 0, 1)))
+  expect_equal(odd_py |> dplyr::pull(exposure) |> sum(),
+               odd_split |> dplyr::pull(exposure_pol) |> sum())
 })
 
 test_that("expose_split() warns about transactions attached too early", {

--- a/tests/testthat/test-expose.R
+++ b/tests/testthat/test-expose.R
@@ -119,6 +119,17 @@ test_that("Date format checks work", {
                regexp = "Missing values are not allowed in the `issue_date`")
 })
 
+test_that("An error is thrown if the default status is a target status", {
+  all_deaths <- dplyr::tribble(
+    ~pol_num, ~status, ~issue_date, ~term_date,
+    1, "Death", as.Date("2011-05-27"), as.Date("2012-03-17"),
+    2, "Death", as.Date("2011-05-27"), as.Date("2012-09-17"))
+  expect_error(all_deaths |>
+    expose(end_date = "2022-12-31", target_status = c("Death", "Surrender")),
+    regexp = "`default_status` is not allowed to be the same as `target_status"
+  )
+})
+
 # split exposure tests
 
 test_that("expose_split() fails when passed non-calendar exposures", {

--- a/tests/testthat/test-transactions.R
+++ b/tests/testthat/test-transactions.R
@@ -50,3 +50,10 @@ test_that("exposed_df persists after adding transactions", {
   expect_s3_class(add_transactions(expo |> group_by(pol_yr), withdrawals),
                   "exposed_df")
 })
+
+test_that("Date format checks work", {
+  withdrawals5 <- withdrawals
+  withdrawals5$trx_date[[42]] <- NA
+  expect_error(add_transactions(expo, withdrawals5),
+               regexp = "Missing values are not allowed in the `trx_date`")
+})


### PR DESCRIPTION
- `expose_split()` bug fixes: 

  - `expose_split()` was updated to respect the values of `start_date` 
    and `end_date` originally passed to the `expose()` function.
  - Future policy anniversary dates falling on February 29th leap days are now
    consistent with `expose()`
  - New tests were added to verify that the sum of policy year exposures
    (`exposure_pol`) after calling `expose_split()` match exposures produced by
    `expose_py()`.
  
- The `expose()` family of functions and `add_transactions()` now allow date 
  columns to be passed as character vectors in YYYY-MM-DD format. Any character 
  vectors are converted to dates behind-the-scenes, and any missing values will
  results in an error message. 

- News and version update